### PR TITLE
daemon: call NodeCleanNeighbors before apiserver connection

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1553,6 +1553,10 @@ func runDaemon() {
 		link.DeleteByName(wireguardTypes.IfaceName)
 	}
 
+	dp := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent)
+	nodeHandler := dp.Node()
+	nodeHandler.NodeCleanNeighbors()
+
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 		if err := k8s.Init(option.Config); err != nil {
@@ -1564,7 +1568,7 @@ func runDaemon() {
 	ctx, cancel := context.WithCancel(server.ServerCtx)
 	d, restoredEndpoints, err := NewDaemon(ctx, cancel,
 		WithDefaultEndpointManager(ctx, endpoint.CheckHealth),
-		linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent))
+		dp)
 	if err != nil {
 		select {
 		case <-server.ServerCtx.Done():


### PR DESCRIPTION
This PR initializes the linuxDatapath _before_ the k8s client in order to to call `linuxDatapath.Node().NodeCleanNeighbors`, which delets all ARP cache (aka ip neighbors) entries with the `PERMANENT` flag.

This is necessary because it is possible for `cilium-agent` on a worker node to crash during a master node replacement procedure in which a new master node comes up with the same IP but different MAC address as a previous node that had not yet been cleared out of the ARP cache by `cilium-agent` before it crashes.

In DOKS context, this fixes a bug where worker nodes can get stuck in a `NotReady` state during a master node recycle.