### PR TITLE
cherry-picks from upstream on v1.14.14 for conformance test fix

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -47,6 +47,7 @@ cilium-agent [flags]
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M) (default 16381)
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
       --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-proto-diff                                         Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --bpf-lb-rss-ipv4-src-cidr string                           BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
       --bpf-lb-rss-ipv6-src-cidr string                           BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic

--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -24,6 +24,7 @@ cilium service update [flags]
       --k8s-load-balancer               Set service as a k8s LoadBalancer
       --k8s-node-port                   Set service as a k8s NodePort
       --local-redirect                  Set service as Local Redirect
+      --protocol string                 Protocol for service (e.g. TCP, UDP) (default "tcp")
       --states strings                  Backend state(s) as {active(default),terminating,quarantined,maintenance}
 ```
 

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -242,14 +242,14 @@ In this example, services with port ``31940`` were created (one for each of devi
     $ kubectl -n kube-system exec ds/cilium -- cilium service list
     ID   Frontend               Service Type   Backend
     [...]
-    4    10.104.239.135:80      ClusterIP      1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    5    0.0.0.0:31940          NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    6    192.168.178.29:31940   NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    7    172.16.0.29:31940      NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
+    4    10.104.239.135:80/TCP      ClusterIP      1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    5    0.0.0.0:31940/TCP          NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    6    192.168.178.29:31940/TCP   NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    7    172.16.0.29:31940/TCP      NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
 
 Create a variable with the node port for testing:
 

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -37,6 +37,9 @@ type BackendAddress struct {
 	// on related annotation of global service. Applicable for active state only.
 	Preferred bool `json:"preferred,omitempty"`
 
+	// Layer 4 protocol (TCP, UDP, etc)
+	Protocol string `json:"protocol,omitempty"`
+
 	// State of the backend for load-balancing service traffic
 	// Enum: [active terminating quarantined maintenance]
 	State string `json:"state,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2863,6 +2863,9 @@ definitions:
       ip:
         description: Layer 3 address
         type: string
+      protocol:
+        description: Layer 4 protocol (TCP, UDP, etc)
+        type: string
       port:
         description: Layer 4 port number
         type: integer

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1874,6 +1874,10 @@ func init() {
           "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
           "type": "boolean"
         },
+        "protocol": {
+          "description": "Layer 4 protocol (TCP, UDP, etc)",
+          "type": "string"
+        },
         "state": {
           "description": "State of the backend for load-balancing service traffic",
           "type": "string",
@@ -7253,6 +7257,10 @@ func init() {
         "preferred": {
           "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
           "type": "boolean"
+        },
+        "protocol": {
+          "description": "Layer 4 protocol (TCP, UDP, etc)",
+          "type": "string"
         },
         "state": {
           "description": "State of the backend for load-balancing service traffic",

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -40,6 +40,9 @@ static __always_inline __maybe_unused bool is_v6_loopback(const union v6addr *da
 }
 
 /* Hack due to missing narrow ctx access. */
+#define ctx_protocol(__ctx) ((__u8)(volatile __u32)(__ctx)->protocol)
+
+/* Hack due to missing narrow ctx access. */
 static __always_inline __maybe_unused __be16
 ctx_dst_port(const struct bpf_sock_addr *ctx)
 {
@@ -104,12 +107,12 @@ bool sock_is_health_check(struct bpf_sock_addr *ctx __maybe_unused)
 static __always_inline __maybe_unused
 __u64 sock_select_slot(struct bpf_sock_addr *ctx)
 {
-	return ctx->protocol == IPPROTO_TCP ?
+	return ctx_protocol(ctx) == IPPROTO_TCP ?
 	       get_prandom_u32() : sock_local_cookie(ctx);
 }
 
 static __always_inline __maybe_unused
-bool sock_proto_enabled(__u32 proto)
+bool sock_proto_enabled(__u8 proto)
 {
 	switch (proto) {
 	case IPPROTO_TCP:
@@ -294,10 +297,12 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb4_backend *backend;
 	struct lb4_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	__u32 dst_ip = ctx->user_ip4;
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
+		.proto		= protocol,
 	}, orig_key = key;
 	struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -309,7 +314,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(protocol))
 		return -ENOTSUP;
 
 	/* In case a direct match fails, we try to look-up surrogate
@@ -317,8 +322,13 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * HostPort services.
 	 */
 	svc = lb4_lookup_service(&key, true, false);
-	if (!svc)
+	if (!svc) {
+		/* Restore the original key's protocol as lb4_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
+	}
 	if (!svc)
 		return -ENXIO;
 	if (svc->count == 0 && !lb4_svc_is_l7loadbalancer(svc))
@@ -477,23 +487,30 @@ int cil_sock4_connect(struct bpf_sock_addr *ctx)
 static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 					     struct bpf_sock *ctx_full)
 {
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb4_service *svc;
 	struct lb4_key key = {
 		.address	= ctx->src_ip4,
 		.dport		= ctx_src_port(ctx),
+		.proto		= protocol,
 	};
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(protocol) ||
 	    !ctx_in_hostns(ctx_full, NULL))
 		return 0;
 
 	svc = lb4_lookup_service(&key, true, false);
-	if (!svc)
+	if (!svc) {
 		/* Perform a wildcard lookup for the case where the caller
 		 * tries to bind to loopback or an address with host identity
 		 * (without remote hosts).
+		 *
+		 * Restore the original key's protocol as lb4_lookup_service
+		 * has overwritten it.
 		 */
+		key.proto = protocol;
 		svc = sock4_wildcard_lookup(&key, false, false, true);
+	}
 
 	/* If the sockaddr of this socket overlaps with a NodePort,
 	 * LoadBalancer or ExternalIP service. We must reject this
@@ -540,7 +557,7 @@ static __always_inline int __sock4_pre_bind(struct bpf_sock_addr *ctx,
 		.peer = {
 			.address	= ctx->user_ip4,
 			.port		= ctx_dst_port(ctx),
-			.proto		= (__u8)ctx->protocol,
+			.proto		= ctx_protocol(ctx),
 		},
 	};
 	int ret;
@@ -556,7 +573,7 @@ int cil_sock4_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(ctx_protocol(ctx)) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return ret;
 	if (sock_is_health_check(ctx) &&
@@ -573,6 +590,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 {
 	struct ipv4_revnat_entry *val;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	__u32 dst_ip = ctx->user_ip4;
 	struct ipv4_revnat_tuple key = {
 		.cookie		= sock_local_cookie(ctx_full),
@@ -588,12 +606,18 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		struct lb4_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= protocol,
 		};
 
 		svc = lb4_lookup_service(&svc_key, true, false);
-		if (!svc)
+		if (!svc) {
+			/* Restore the original key's protocol as lb4_lookup_service
+			 * has overwritten it.
+			 */
+			svc_key.proto = protocol;
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
+		}
 		if (!svc || svc->rev_nat_index != val->rev_nat_index ||
 		    (svc->count == 0 && !lb4_svc_is_l7loadbalancer(svc))) {
 			map_delete_elem(&LB4_REVERSE_NAT_SK_MAP, &key);
@@ -810,7 +834,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 		return -ENXIO;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -840,7 +864,7 @@ sock6_post_bind_v4_in_v6(struct bpf_sock *ctx __maybe_unused)
 		return 0;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol = ctx->protocol;
+	fake_ctx.protocol = ctx_protocol(ctx);
 	fake_ctx.src_ip4  = addr6.p4;
 	fake_ctx.src_port = ctx->src_port;
 
@@ -851,12 +875,14 @@ sock6_post_bind_v4_in_v6(struct bpf_sock *ctx __maybe_unused)
 
 static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 {
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_service *svc;
 	struct lb6_key key = {
 		.dport		= ctx_src_port(ctx),
+		.proto		= protocol,
 	};
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(protocol) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return 0;
 
@@ -864,6 +890,10 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	svc = lb6_lookup_service(&key, true, false);
 	if (!svc) {
+		/* Restore the original key's protocol as lb6_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
 			return sock6_post_bind_v4_in_v6(ctx);
@@ -904,7 +934,7 @@ sock6_pre_bind_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 	ctx_get_v6_address(ctx, &addr6);
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -935,7 +965,7 @@ static __always_inline int __sock6_pre_bind(struct bpf_sock_addr *ctx)
 	struct lb6_health val = {
 		.peer = {
 			.port		= ctx_dst_port(ctx),
-			.proto		= (__u8)ctx->protocol,
+			.proto		= ctx_protocol(ctx),
 		},
 	};
 	int ret = 0;
@@ -957,7 +987,7 @@ int cil_sock6_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(ctx_protocol(ctx)) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return ret;
 	if (sock_is_health_check(ctx) &&
@@ -978,8 +1008,10 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb6_backend *backend;
 	struct lb6_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_key key = {
 		.dport		= dst_port,
+		.proto		= protocol,
 	}, orig_key;
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -991,15 +1023,20 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(protocol))
 		return -ENOTSUP;
 
 	ctx_get_v6_address(ctx, &key.address);
 	memcpy(&orig_key, &key, sizeof(key));
 
 	svc = lb6_lookup_service(&key, true, false);
-	if (!svc)
+	if (!svc) {
+		/* Restore the original key's protocol as lb6_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
+	}
 	if (!svc)
 		return sock6_xlate_v4_in_v6(ctx, udp_only);
 	if (svc->count == 0 && !lb6_svc_is_l7loadbalancer(svc))
@@ -1144,7 +1181,7 @@ sock6_xlate_rev_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 		return -ENXIO;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -1167,6 +1204,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 	struct ipv6_revnat_tuple key = {};
 	struct ipv6_revnat_entry *val;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 
 	key.cookie = sock_local_cookie(ctx);
 	key.port = dst_port;
@@ -1181,12 +1219,18 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		struct lb6_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= protocol,
 		};
 
 		svc = lb6_lookup_service(&svc_key, true, false);
-		if (!svc)
+		if (!svc) {
+			/* Restore the original key's protocol as lb6_lookup_service
+			 * has overwritten it.
+			 */
+			svc_key.proto = protocol;
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));
+		}
 		if (!svc || svc->rev_nat_index != val->rev_nat_index ||
 		    (svc->count == 0 && !lb6_svc_is_l7loadbalancer(svc))) {
 			map_delete_elem(&LB6_REVERSE_NAT_SK_MAP, &key);

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -302,7 +302,9 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	}, orig_key = key;
 	struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -326,7 +328,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		/* Restore the original key's protocol as lb4_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb4_key_set_protocol(&key, protocol);
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
 	}
 	if (!svc)
@@ -492,7 +494,9 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	struct lb4_key key = {
 		.address	= ctx->src_ip4,
 		.dport		= ctx_src_port(ctx),
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	};
 
 	if (!sock_proto_enabled(protocol) ||
@@ -508,7 +512,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 		 * Restore the original key's protocol as lb4_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb4_key_set_protocol(&key, protocol);
 		svc = sock4_wildcard_lookup(&key, false, false, true);
 	}
 
@@ -606,7 +610,9 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		struct lb4_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 			.proto		= protocol,
+#endif
 		};
 
 		svc = lb4_lookup_service(&svc_key, true, false);
@@ -614,7 +620,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 			/* Restore the original key's protocol as lb4_lookup_service
 			 * has overwritten it.
 			 */
-			svc_key.proto = protocol;
+			lb4_key_set_protocol(&svc_key, protocol);
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
 		}
@@ -879,7 +885,9 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 	struct lb6_service *svc;
 	struct lb6_key key = {
 		.dport		= ctx_src_port(ctx),
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	};
 
 	if (!sock_proto_enabled(protocol) ||
@@ -893,7 +901,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 		/* Restore the original key's protocol as lb6_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb6_key_set_protocol(&key, protocol);
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
 			return sock6_post_bind_v4_in_v6(ctx);
@@ -1011,7 +1019,9 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_key key = {
 		.dport		= dst_port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	}, orig_key;
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -1034,7 +1044,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		/* Restore the original key's protocol as lb6_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb6_key_set_protocol(&key, protocol);
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	}
 	if (!svc)
@@ -1219,7 +1229,9 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		struct lb6_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 			.proto		= protocol,
+#endif
 		};
 
 		svc = lb6_lookup_service(&svc_key, true, false);
@@ -1227,7 +1239,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 			/* Restore the original key's protocol as lb6_lookup_service
 			 * has overwritten it.
 			 */
-			svc_key.proto = protocol;
+			lb6_key_set_protocol(&svc_key, protocol);
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));
 		}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -947,7 +947,7 @@ struct lb6_key {
 	union v6addr address;	/* Service virtual IPv6 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };
@@ -1005,7 +1005,7 @@ struct lb4_key {
 	__be32 address;		/* Service virtual IPv4 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -488,9 +488,18 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 }
 
 static __always_inline void
+lb6_key_set_protocol(struct lb6_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	key->proto = protocol;
+#endif
+}
+
+static __always_inline void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
-	key->proto = tuple->nexthdr;
+	lb6_key_set_protocol(key, tuple->nexthdr);
 	ipv6_addr_copy(&key->address, &tuple->daddr);
 	key->dport = tuple->sport;
 }
@@ -1021,6 +1030,12 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
 	return NULL;
 }
 
+static __always_inline void
+lb6_key_set_protocol(struct lb6_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+}
+
 static __always_inline
 struct lb6_service *__lb6_lookup_backend_slot(struct lb6_key *key __maybe_unused)
 {
@@ -1145,9 +1160,18 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 }
 
 static __always_inline void
+lb4_key_set_protocol(struct lb4_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	key->proto = protocol;
+#endif
+}
+
+static __always_inline void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
-	key->proto = tuple->nexthdr;
+	lb4_key_set_protocol(key, tuple->nexthdr);
 	key->address = tuple->daddr;
 	/* CT tuple has ports in reverse order: */
 	key->dport = tuple->sport;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -594,6 +594,15 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
 	svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	/* If there are no elements for a specific protocol, check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+	}
+#endif
+
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_two_scopes(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */
@@ -1270,6 +1279,15 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
 	svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	/* If there are no elements for a specific protocol, check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+	}
+#endif
+
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_two_scopes(svc))
 			/* Packets for L7 LB are redirected even when there are no backends. */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -490,8 +490,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 static __always_inline void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	ipv6_addr_copy(&key->address, &tuple->daddr);
 	key->dport = tuple->sport;
 }
@@ -1148,8 +1147,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 static __always_inline void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	key->address = tuple->daddr;
 	/* CT tuple has ports in reverse order: */
 	key->dport = tuple->sport;

--- a/cilium/cmd/bpf_lb_list.go
+++ b/cilium/cmd/bpf_lb_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 const (
@@ -105,12 +106,12 @@ func dumpSVC(serviceList map[string][]string) {
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {
-			fmtStr := "%s:%d (%d) (%d)"
+			fmtStr := "%s:%d/%s (%d) (%d)"
 			if svcKey.IsIPv6() {
-				fmtStr = "[%s]:%d (%d) (%d)"
+				fmtStr = "[%s]:%d/%s (%d) (%d)"
 			}
 			entry = fmt.Sprintf(fmtStr, backend.GetAddress(),
-				backend.GetPort(), revNATID, backendSlot)
+				backend.GetPort(), u8proto.U8proto(backend.GetProtocol()).String(), revNATID, backendSlot)
 		}
 
 		serviceList[svc] = append(serviceList[svc], entry)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -619,6 +619,9 @@ func initializeFlags() {
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	option.BindEnv(Vp, option.LoadBalancerAcceleration)
 
+	flags.Bool(option.LoadBalancerProtocolDifferentiation, true, "Enable support for service protocol differentiation (TCP, UDP, SCTP)")
+	option.BindEnv(Vp, option.LoadBalancerProtocolDifferentiation)
+
 	flags.Uint(option.MaglevTableSize, maglev.DefaultTableSize, "Maglev per service backend table size (parameter M)")
 	option.BindEnv(Vp, option.MaglevTableSize)
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -724,6 +724,9 @@ data:
 {{- if hasKey .Values.loadBalancer "serviceTopology" }}
   enable-service-topology: {{ .Values.loadBalancer.serviceTopology | quote }}
 {{- end }}
+{{- if hasKey .Values.loadBalancer "protocolDifferentiation" }}
+  bpf-lb-proto-diff: {{ .Values.loadBalancer.protocolDifferentiation.enabled | quote }}
+{{- end }}
 
 {{- end }}
 {{- if hasKey .Values.maglev "tableSize" }}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -464,6 +464,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = "128"
 			}
 		}
+
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
 		}
@@ -698,6 +699,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		return err
 	}
 	cDefinesMap["EPHEMERAL_MIN"] = fmt.Sprintf("%d", ephemeralMin)
+
+	if option.Config.LoadBalancerProtocolDifferentiation {
+		cDefinesMap["ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION"] = "1"
+	}
 
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent written format to the writer. This maintains

--- a/pkg/datapath/types/lbmap.go
+++ b/pkg/datapath/types/lbmap.go
@@ -30,9 +30,10 @@ type LBMap interface {
 }
 
 type UpsertServiceParams struct {
-	ID   uint16
-	IP   net.IP
-	Port uint16
+	ID       uint16
+	IP       net.IP
+	Port     uint16
+	Protocol uint8
 
 	// PreferredBackends is a subset of ActiveBackends
 	// Note: this is only used in clustermesh with service affinity annotation.

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -533,13 +533,10 @@ func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRa
 }
 
 // UniquePorts returns a map of all unique ports configured in the service
-func (s *Service) UniquePorts() map[uint16]bool {
-	// We are not discriminating the different L4 protocols on the same L4
-	// port so we create the number of unique sets of service IP + service
-	// port.
-	uniqPorts := map[uint16]bool{}
+func (s *Service) UniquePorts() map[string]bool {
+	uniqPorts := map[string]bool{}
 	for _, p := range s.Ports {
-		uniqPorts[p.Port] = true
+		uniqPorts[p.String()] = true
 	}
 	return uniqPorts
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -945,12 +945,12 @@ func stripServiceProtocol(svc *k8s.Service) *k8s.Service {
 	svc = svc.DeepCopy()
 
 	for _, port := range svc.Ports {
-		port.Protocol = "NONE"
+		port.Protocol = "ANY"
 	}
 
 	for _, nodePort := range svc.NodePorts {
 		for _, port := range nodePort {
-			port.Protocol = "NONE"
+			port.Protocol = "ANY"
 		}
 	}
 
@@ -962,7 +962,7 @@ func stripEndpointsProtocol(endpoints *k8s.Endpoints) *k8s.Endpoints {
 
 	for _, backend := range endpoints.Backends {
 		for _, port := range backend.Ports {
-			port.Protocol = "NONE"
+			port.Protocol = "ANY"
 		}
 	}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -723,53 +723,60 @@ func (k *K8sWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s
 		logfields.K8sNamespace: svc.Namespace,
 	})
 
-	repPorts := svcInfo.UniquePorts()
-
-	frontends := []*loadbalancer.L3n4Addr{}
-
-	for portName, svcPort := range svcInfo.Ports {
-		if !repPorts[svcPort.String()] {
-			continue
-		}
-		repPorts[svcPort.String()] = false
-
-		for _, feIP := range svcInfo.FrontendIPs {
-			fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
-			frontends = append(frontends, fe)
+	for _, checkProtocol := range []bool{true, false} {
+		if !checkProtocol {
+			svcInfo = stripServiceProtocol(svcInfo)
 		}
 
-		for _, nodePortFE := range svcInfo.NodePorts[portName] {
-			frontends = append(frontends, &nodePortFE.L3n4Addr)
-			if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
-				cpFE := nodePortFE.L3n4Addr.DeepCopy()
-				cpFE.Scope = loadbalancer.ScopeInternal
-				frontends = append(frontends, cpFE)
+		repPorts := svcInfo.UniquePorts()
+
+		frontends := []*loadbalancer.L3n4Addr{}
+
+		for portName, svcPort := range svcInfo.Ports {
+			if !repPorts[svcPort.String()] {
+				continue
+			}
+			repPorts[svcPort.String()] = false
+
+			for _, feIP := range svcInfo.FrontendIPs {
+				fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
+				frontends = append(frontends, fe)
+			}
+
+			for _, nodePortFE := range svcInfo.NodePorts[portName] {
+				frontends = append(frontends, &nodePortFE.L3n4Addr)
+				if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+					cpFE := nodePortFE.L3n4Addr.DeepCopy()
+					cpFE.Scope = loadbalancer.ScopeInternal
+					frontends = append(frontends, cpFE)
+				}
+			}
+
+			for _, k8sExternalIP := range svcInfo.K8sExternalIPs {
+				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(k8sExternalIP), svcPort.Port, loadbalancer.ScopeExternal))
+			}
+
+			for _, ip := range svcInfo.LoadBalancerIPs {
+				addrCluster := cmtypes.MustAddrClusterFromIP(ip)
+				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeExternal))
+				if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+					frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeInternal))
+				}
 			}
 		}
 
-		for _, k8sExternalIP := range svcInfo.K8sExternalIPs {
-			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(k8sExternalIP), svcPort.Port, loadbalancer.ScopeExternal))
-		}
-
-		for _, ip := range svcInfo.LoadBalancerIPs {
-			addrCluster := cmtypes.MustAddrClusterFromIP(ip)
-			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeExternal))
-			if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
-				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeInternal))
+		for _, fe := range frontends {
+			if found, err := k.svcManager.DeleteService(*fe); err != nil {
+				scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
+					Warn("Error deleting service by frontend")
+			} else if !found {
+				scopedLog.WithField(logfields.Object, logfields.Repr(fe)).Warn("service not found")
+			} else {
+				scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.AddrCluster.String(), fe.Port)
 			}
 		}
 	}
 
-	for _, fe := range frontends {
-		if found, err := k.svcManager.DeleteService(*fe); err != nil {
-			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
-				Warn("Error deleting service by frontend")
-		} else if !found {
-			scopedLog.WithField(logfields.Object, logfields.Repr(fe)).Warn("service not found")
-		} else {
-			scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.AddrCluster.String(), fe.Port)
-		}
-	}
 	return nil
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -930,6 +930,38 @@ func hashSVCMap(svcs []loadbalancer.SVC) map[string]loadbalancer.L3n4Addr {
 	return m
 }
 
+func stripServiceProtocol(svc *k8s.Service) *k8s.Service {
+	if svc == nil {
+		return nil
+	}
+
+	svc = svc.DeepCopy()
+
+	for _, port := range svc.Ports {
+		port.Protocol = "NONE"
+	}
+
+	for _, nodePort := range svc.NodePorts {
+		for _, port := range nodePort {
+			port.Protocol = "NONE"
+		}
+	}
+
+	return svc
+}
+
+func stripEndpointsProtocol(endpoints *k8s.Endpoints) *k8s.Endpoints {
+	endpoints = endpoints.DeepCopy()
+
+	for _, backend := range endpoints.Backends {
+		for _, port := range backend.Ports {
+			port.Protocol = "NONE"
+		}
+	}
+
+	return endpoints
+}
+
 func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, endpoints *k8s.Endpoints) error {
 	// Headless services do not need any datapath implementation
 	if svc.IsHeadless {
@@ -940,6 +972,12 @@ func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, e
 		logfields.K8sSvcName:   svcID.Name,
 		logfields.K8sNamespace: svcID.Namespace,
 	})
+
+	if !option.Config.LoadBalancerProtocolDifferentiation {
+		oldSvc = stripServiceProtocol(oldSvc)
+		svc = stripServiceProtocol(svc)
+		endpoints = stripEndpointsProtocol(endpoints)
+	}
 
 	svcs := datapathSVCs(svc, endpoints)
 	svcMap := hashSVCMap(svcs)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -728,10 +728,10 @@ func (k *K8sWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s
 	frontends := []*loadbalancer.L3n4Addr{}
 
 	for portName, svcPort := range svcInfo.Ports {
-		if !repPorts[svcPort.Port] {
+		if !repPorts[svcPort.String()] {
 			continue
 		}
-		repPorts[svcPort.Port] = false
+		repPorts[svcPort.String()] = false
 
 		for _, feIP := range svcInfo.FrontendIPs {
 			fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
@@ -866,10 +866,10 @@ func datapathSVCs(svc *k8s.Service, endpoints *k8s.Endpoints) (svcs []loadbalanc
 
 	clusterIPPorts := map[loadbalancer.FEPortName]*loadbalancer.L4Addr{}
 	for fePortName, fePort := range svc.Ports {
-		if !uniqPorts[fePort.Port] {
+		if !uniqPorts[fePort.String()] {
 			continue
 		}
-		uniqPorts[fePort.Port] = false
+		uniqPorts[fePort.String()] = false
 		clusterIPPorts[fePortName] = fePort
 	}
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -526,6 +526,8 @@ func IsValidBackendState(state string) bool {
 
 func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
+	case "none":
+		return NONE, nil
 	case "tcp":
 		return TCP, nil
 	case "udp":

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -232,6 +232,8 @@ func (s ServiceFlags) UInt16() uint16 {
 const (
 	// NONE type.
 	NONE = L4Type("NONE")
+	// ANY type.
+	ANY = L4Type("ANY")
 	// TCP type.
 	TCP = L4Type("TCP")
 	// UDP type.
@@ -528,6 +530,8 @@ func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
 	case "none":
 		return NONE, nil
+	case "any":
+		return ANY, nil
 	case "tcp":
 		return TCP, nil
 	case "udp":
@@ -548,7 +552,7 @@ func NewL4TypeFromNumber(proto uint8) L4Type {
 	case 132:
 		return SCTP
 	default:
-		return NONE
+		return ANY
 	}
 }
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // SVCType is a type of a service.
@@ -229,6 +230,7 @@ func (s ServiceFlags) UInt16() uint16 {
 }
 
 const (
+	// NONE type.
 	NONE = L4Type("NONE")
 	// TCP type.
 	TCP = L4Type("TCP")
@@ -535,6 +537,19 @@ func NewL4Type(name string) (L4Type, error) {
 	}
 }
 
+func NewL4TypeFromNumber(proto uint8) L4Type {
+	switch proto {
+	case 6:
+		return TCP
+	case 17:
+		return UDP
+	case 132:
+		return SCTP
+	default:
+		return NONE
+	}
+}
+
 // L4Addr is an abstraction for the backend port with a L4Type, usually tcp or udp, and
 // the Port number.
 //
@@ -556,6 +571,22 @@ func (l *L4Addr) DeepEqual(o *L4Addr) bool {
 // NewL4Addr creates a new L4Addr.
 func NewL4Addr(protocol L4Type, number uint16) *L4Addr {
 	return &L4Addr{Protocol: protocol, Port: number}
+}
+
+// Equals returns true if both L4Addr are considered equal.
+func (l *L4Addr) Equals(o *L4Addr) bool {
+	switch {
+	case (l == nil) != (o == nil):
+		return false
+	case (l == nil) && (o == nil):
+		return true
+	}
+	return l.Port == o.Port && l.Protocol == o.Protocol
+}
+
+// String returns a string representation of an L4Addr
+func (l *L4Addr) String() string {
+	return fmt.Sprintf("%d/%s", l.Port, l.Protocol)
 }
 
 // L3n4Addr is used to store, as an unique L3+L4 address in the KVStore. It also
@@ -659,8 +690,7 @@ func NewBackendFromBackendModel(base *models.BackendAddress) (*Backend, error) {
 		return nil, fmt.Errorf("missing IP address")
 	}
 
-	// FIXME: Should this be NONE ?
-	l4addr := NewL4Addr(NONE, base.Port)
+	l4addr := NewL4Addr(base.Protocol, base.Port)
 	addrCluster, err := cmtypes.ParseAddrCluster(*base.IP)
 	if err != nil {
 		return nil, err
@@ -693,8 +723,7 @@ func NewL3n4AddrFromBackendModel(base *models.BackendAddress) (*L3n4Addr, error)
 		return nil, fmt.Errorf("missing IP address")
 	}
 
-	// FIXME: Should this be NONE ?
-	l4addr := NewL4Addr(NONE, base.Port)
+	l4addr := NewL4Addr(base.Protocol, base.Port)
 	addrCluster, err := cmtypes.ParseAddrCluster(*base.IP)
 	if err != nil {
 		return nil, err
@@ -712,9 +741,10 @@ func (a *L3n4Addr) GetModel() *models.FrontendAddress {
 		scope = models.FrontendAddressScopeInternal
 	}
 	return &models.FrontendAddress{
-		IP:    a.AddrCluster.String(),
-		Port:  a.Port,
-		Scope: scope,
+		IP:       a.AddrCluster.String(),
+		Protocol: a.Protocol,
+		Port:     a.Port,
+		Scope:    scope,
 	}
 }
 
@@ -727,6 +757,7 @@ func (b *Backend) GetBackendModel() *models.BackendAddress {
 	stateStr, _ := b.State.String()
 	return &models.BackendAddress{
 		IP:        &addrClusterStr,
+		Protocol:  b.Protocol,
 		Port:      b.Port,
 		NodeName:  b.NodeName,
 		State:     stateStr,
@@ -735,17 +766,10 @@ func (b *Backend) GetBackendModel() *models.BackendAddress {
 	}
 }
 
-// String returns the L3n4Addr in the "IPv4:Port[/Scope]" format for IPv4 and
-// "[IPv6]:Port[/Scope]" format for IPv6.
+// String returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]" format for IPv4 and
+// "[IPv6]:Port/Protocol[/Scope]" format for IPv6.
 func (a *L3n4Addr) String() string {
-	var scope string
-	if a.Scope == ScopeInternal {
-		scope = "/i"
-	}
-	if a.IsIPv6() {
-		return fmt.Sprintf("[%s]:%d%s", a.AddrCluster.String(), a.Port, scope)
-	}
-	return fmt.Sprintf("%s:%d%s", a.AddrCluster.String(), a.Port, scope)
+	return a.StringWithProtocol()
 }
 
 // StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
@@ -763,8 +787,6 @@ func (a *L3n4Addr) StringWithProtocol() string {
 
 // StringID returns the L3n4Addr as string to be used for unique identification
 func (a *L3n4Addr) StringID() string {
-	// This does not include the protocol right now as the datapath does
-	// not include the protocol in the lookup of the service IP.
 	return a.String()
 }
 
@@ -772,14 +794,15 @@ func (a *L3n4Addr) StringID() string {
 // Note: the resulting string is meant to be used as a key for maps and is not
 // readable by a human eye when printed out.
 func (a L3n4Addr) Hash() string {
-	const lenProto = 0 // proto is omitted for now
+	const lenProto = 1 // proto is uint8
 	const lenScope = 1 // scope is uint8 which is an alias for byte
 	const lenPort = 2  // port is uint16 which is 2 bytes
 
 	b := make([]byte, cmtypes.AddrClusterLen+lenProto+lenScope+lenPort)
 	ac20 := a.AddrCluster.As20()
 	copy(b, ac20[:])
-	// FIXME: add Protocol once we care about protocols
+	u8p, _ := u8proto.ParseProtocol(a.Protocol)
+	b[net.IPv6len] = byte(u8p)
 	// scope is a uint8 which is an alias for byte so a cast is safe
 	b[net.IPv6len+lenProto] = byte(a.Scope)
 	// port is a uint16, so 2 bytes

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -250,6 +250,7 @@ func NewService4Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 func (k *Service4Key) String() string {
 	kHost := k.ToHost().(*Service4Key)
 	addr := net.JoinHostPort(kHost.Address.String(), fmt.Sprintf("%d", kHost.Port))
+	addr += fmt.Sprintf("/%s", u8proto.U8proto(kHost.Proto).String())
 	if kHost.Scope == loadbalancer.ScopeInternal {
 		addr += "/i"
 	}
@@ -268,6 +269,7 @@ func (k *Service4Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service4Key) GetScope() uint8         { return k.Scope }
 func (k *Service4Key) GetAddress() net.IP      { return k.Address.IP() }
 func (k *Service4Key) GetPort() uint16         { return k.Port }
+func (k *Service4Key) GetProtocol() uint8      { return k.Proto }
 func (k *Service4Key) MapDelete() error        { return k.Map().Delete(k.ToNetwork()) }
 
 func (k *Service4Key) RevNatValue() RevNatValue {
@@ -413,8 +415,9 @@ func (b *Backend4Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4Value) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), 0)
 }
-func (b *Backend4Value) GetPort() uint16 { return b.Port }
-func (b *Backend4Value) GetFlags() uint8 { return b.Flags }
+func (b *Backend4Value) GetPort() uint16    { return b.Port }
+func (b *Backend4Value) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend4Value) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
@@ -475,8 +478,9 @@ func (b *Backend4ValueV3) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4ValueV3) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), uint32(b.ClusterID))
 }
-func (b *Backend4ValueV3) GetPort() uint16 { return b.Port }
-func (b *Backend4ValueV3) GetFlags() uint8 { return b.Flags }
+func (b *Backend4ValueV3) GetPort() uint16    { return b.Port }
+func (b *Backend4ValueV3) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend4ValueV3) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend4ValueV3) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -147,9 +147,9 @@ func NewService6Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 func (k *Service6Key) String() string {
 	kHost := k.ToHost().(*Service6Key)
 	if kHost.Scope == loadbalancer.ScopeInternal {
-		return fmt.Sprintf("[%s]:%d/i (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
+		return fmt.Sprintf("[%s]:%d/%s/i (%d)", kHost.Address, kHost.Port, u8proto.U8proto(kHost.Proto).String(), kHost.BackendSlot)
 	} else {
-		return fmt.Sprintf("[%s]:%d (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
+		return fmt.Sprintf("[%s]:%d/%s (%d)", kHost.Address, kHost.Port, u8proto.U8proto(kHost.Proto).String(), kHost.BackendSlot)
 	}
 }
 
@@ -164,6 +164,7 @@ func (k *Service6Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service6Key) GetScope() uint8         { return k.Scope }
 func (k *Service6Key) GetAddress() net.IP      { return k.Address.IP() }
 func (k *Service6Key) GetPort() uint16         { return k.Port }
+func (k *Service6Key) GetProtocol() uint8      { return k.Proto }
 func (k *Service6Key) MapDelete() error        { return k.Map().Delete(k.ToNetwork()) }
 
 func (k *Service6Key) RevNatValue() RevNatValue {
@@ -307,8 +308,9 @@ func (b *Backend6Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6Value) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), 0)
 }
-func (b *Backend6Value) GetPort() uint16 { return b.Port }
-func (b *Backend6Value) GetFlags() uint8 { return b.Flags }
+func (b *Backend6Value) GetPort() uint16    { return b.Port }
+func (b *Backend6Value) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend6Value) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
@@ -369,8 +371,9 @@ func (b *Backend6ValueV3) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6ValueV3) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), uint32(b.ClusterID))
 }
-func (b *Backend6ValueV3) GetPort() uint16 { return b.Port }
-func (b *Backend6ValueV3) GetFlags() uint8 { return b.Flags }
+func (b *Backend6ValueV3) GetPort() uint16    { return b.Port }
+func (b *Backend6ValueV3) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend6ValueV3) GetFlags() uint8    { return b.Flags }
 
 func (v *Backend6ValueV3) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -6,8 +6,6 @@ package lbmap
 import (
 	"errors"
 	"fmt"
-	"net"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -76,10 +74,10 @@ func (lbmap *LBBPFMap) upsertServiceProto(p *datapathTypes.UpsertServiceParams, 
 	backendsOk := ipv6 || !ipv6 && p.NatPolicy != loadbalancer.SVCNatPolicyNat46
 
 	if ipv6 {
-		svcKey = NewService6Key(p.IP, p.Port, u8proto.ANY, p.Scope, 0)
+		svcKey = NewService6Key(p.IP, p.Port, u8proto.U8proto(p.Protocol), p.Scope, 0)
 		svcVal = &Service6Value{}
 	} else {
-		svcKey = NewService4Key(p.IP, p.Port, u8proto.ANY, p.Scope, 0)
+		svcKey = NewService4Key(p.IP, p.Port, u8proto.U8proto(p.Protocol), p.Scope, 0)
 		svcVal = &Service4Value{}
 	}
 
@@ -200,11 +198,16 @@ func deleteServiceProto(svc loadbalancer.L3n4AddrID, backendCount int, useMaglev
 		revNATKey RevNatKey
 	)
 
+	u8p, err := u8proto.ParseProtocol(svc.Protocol)
+	if err != nil {
+		return err
+	}
+
 	if ipv6 {
-		svcKey = NewService6Key(svc.AddrCluster.AsNetIP(), svc.Port, u8proto.ANY, svc.Scope, 0)
+		svcKey = NewService6Key(svc.AddrCluster.AsNetIP(), svc.Port, u8p, svc.Scope, 0)
 		revNATKey = NewRevNat6Key(uint16(svc.ID))
 	} else {
-		svcKey = NewService4Key(svc.AddrCluster.AsNetIP(), svc.Port, u8proto.ANY, svc.Scope, 0)
+		svcKey = NewService4Key(svc.AddrCluster.AsNetIP(), svc.Port, u8p, svc.Scope, 0)
 		revNATKey = NewRevNat4Key(uint16(svc.ID))
 	}
 
@@ -454,11 +457,8 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 		if svcKey.GetBackendSlot() == 0 {
 			// Build a cache of flags stored in the value of the master key to
 			// map it later.
-			// FIXME proto is being ignored everywhere in the datapath.
-			addrStr := svcKey.GetAddress().String()
-			portStr := strconv.Itoa(int(svcKey.GetPort()))
-			flagsCache[net.JoinHostPort(addrStr, portStr)] = loadbalancer.ServiceFlags(svcValue.GetFlags())
 
+			flagsCache[fe.String()] = loadbalancer.ServiceFlags(svcValue.GetFlags())
 			newSVCMap.addFE(fe)
 			return
 		}
@@ -502,13 +502,11 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 	newSVCList := make([]*loadbalancer.SVC, 0, len(newSVCMap))
 	for hash := range newSVCMap {
 		svc := newSVCMap[hash]
-		addrStr := svc.Frontend.AddrCluster.String()
-		portStr := strconv.Itoa(int(svc.Frontend.Port))
-		host := net.JoinHostPort(addrStr, portStr)
-		svc.Type = flagsCache[host].SVCType()
-		svc.ExtTrafficPolicy = flagsCache[host].SVCExtTrafficPolicy()
-		svc.IntTrafficPolicy = flagsCache[host].SVCIntTrafficPolicy()
-		svc.NatPolicy = flagsCache[host].SVCNatPolicy(svc.Frontend.L3n4Addr)
+		key := svc.Frontend.String()
+		svc.Type = flagsCache[key].SVCType()
+		svc.ExtTrafficPolicy = flagsCache[key].SVCExtTrafficPolicy()
+		svc.IntTrafficPolicy = flagsCache[key].SVCIntTrafficPolicy()
+		svc.NatPolicy = flagsCache[key].SVCNatPolicy(svc.Frontend.L3n4Addr)
 		newSVCList = append(newSVCList, &svc)
 	}
 
@@ -546,7 +544,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		ip := backendVal.GetAddress()
 		addrCluster := cmtypes.MustAddrClusterFromIP(ip)
 		port := backendVal.GetPort()
-		proto := loadbalancer.NONE
+		proto := loadbalancer.NewL4TypeFromNumber(backendVal.GetProtocol())
 		state := loadbalancer.GetBackendStateFromFlags(backendVal.GetFlags())
 		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, addrCluster, port, state)
 		lbBackends = append(lbBackends, lbBackend)
@@ -611,11 +609,17 @@ func getBackend(backend *loadbalancer.Backend, ipv6 bool) (Backend, error) {
 		return lbBackend, fmt.Errorf("invalid backend ID 0")
 	}
 
+	u8p, err := u8proto.ParseProtocol(backend.Protocol)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse protocol lbBackend (%d, %s, %d, %s, %t): %w",
+			backend.ID, backend.AddrCluster.String(), backend.Port, backend.Protocol, ipv6, err)
+	}
+
 	if ipv6 {
-		lbBackend, err = NewBackend6V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
+		lbBackend, err = NewBackend6V3(backend.ID, backend.AddrCluster, backend.Port, u8p,
 			backend.State)
 	} else {
-		lbBackend, err = NewBackend4V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
+		lbBackend, err = NewBackend4V3(backend.ID, backend.AddrCluster, backend.Port, u8p,
 			backend.State)
 	}
 	if err != nil {

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
-// ServiceKey is the interface describing protocol independent key for services map v2.
+// ServiceKey is the interface describing key for services map v2.
 type ServiceKey interface {
 	bpf.MapKey
 
@@ -41,6 +41,9 @@ type ServiceKey interface {
 
 	// Get frontend port
 	GetPort() uint16
+
+	// Get protocol
+	GetProtocol() uint8
 
 	// Returns a RevNatValue matching a ServiceKey
 	RevNatValue() RevNatValue
@@ -113,7 +116,7 @@ type BackendKey interface {
 	GetID() loadbalancer.BackendID
 }
 
-// BackendValue is the interface describing protocol independent backend value.
+// BackendValue is the interface describing backend value.
 type BackendValue interface {
 	bpf.MapValue
 
@@ -125,6 +128,9 @@ type BackendValue interface {
 
 	// Get backend port
 	GetPort() uint16
+
+	// Get backend protocol
+	GetProtocol() uint8
 
 	// Get backend flags
 	GetFlags() uint8
@@ -177,7 +183,8 @@ type RevNatValue interface {
 func svcFrontend(svcKey ServiceKey, svcValue ServiceValue) *loadbalancer.L3n4AddrID {
 	feIP := svcKey.GetAddress()
 	feAddrCluster := cmtypes.MustAddrClusterFromIP(feIP)
-	feL3n4Addr := loadbalancer.NewL3n4Addr(loadbalancer.NONE, feAddrCluster, svcKey.GetPort(), svcKey.GetScope())
+	p := loadbalancer.NewL4TypeFromNumber(svcKey.GetProtocol())
+	feL3n4Addr := loadbalancer.NewL3n4Addr(p, feAddrCluster, svcKey.GetPort(), svcKey.GetScope())
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
 		ID:       loadbalancer.ID(svcValue.GetRevNat()),
@@ -189,7 +196,7 @@ func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbal
 	beIP := backend.GetAddress()
 	beAddrCluster := cmtypes.MustAddrClusterFromIP(beIP)
 	bePort := backend.GetPort()
-	beProto := loadbalancer.NONE
+	beProto := loadbalancer.NewL4TypeFromNumber(backend.GetProtocol())
 	beState := loadbalancer.GetBackendStateFromFlags(backend.GetFlags())
 	beBackend := loadbalancer.NewBackendWithState(backendID, beProto, beAddrCluster, bePort, beState)
 	return beBackend

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -285,6 +285,13 @@ const (
 	// Alias to NodePortAcceleration
 	LoadBalancerAcceleration = "bpf-lb-acceleration"
 
+	// LoadBalancerExternalControlPlane switch skips connectivity to kube-apiserver
+	// which is relevant in lb-only mode
+	LoadBalancerExternalControlPlane = "bpf-lb-external-control-plane"
+
+	// LoadBalancerProtocolDifferentiation enables support for service protocol differentiation (TCP, UDP, SCTP)
+	LoadBalancerProtocolDifferentiation = "bpf-lb-proto-diff"
+
 	// MaglevTableSize determines the size of the backend table per service
 	MaglevTableSize = "bpf-lb-maglev-table-size"
 
@@ -2058,6 +2065,13 @@ type DaemonConfig struct {
 	LoadBalancerRSSv6CIDR string
 	LoadBalancerRSSv6     net.IPNet
 
+	// LoadBalancerExternalControlPlane tells whether to not use kube-apiserver as
+	// its control plane in lb-only mode.
+	LoadBalancerExternalControlPlane bool
+
+	// LoadBalancerProtocolDifferentiation enables support for service protocol differentiation (TCP, UDP, SCTP)
+	LoadBalancerProtocolDifferentiation bool
+
 	// EnablePMTUDiscovery indicates whether to send ICMP fragmentation-needed
 	// replies to the client (when needed).
 	EnablePMTUDiscovery bool
@@ -3590,6 +3604,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
+
+	c.LoadBalancerProtocolDifferentiation = vp.GetBool(LoadBalancerProtocolDifferentiation)
 }
 
 func (c *DaemonConfig) populateDevices(vp *viper.Viper) {

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -51,6 +51,7 @@ func NewIDAllocator(nextID uint32, maxID uint32) *IDAllocator {
 	}
 }
 
+// addID assumes the lock is held
 func (alloc *IDAllocator) addID(svc loadbalancer.L3n4Addr, id uint32) *loadbalancer.L3n4AddrID {
 	svcID := newID(svc, id)
 	alloc.entitiesID[id] = svcID

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1151,8 +1151,36 @@ func (s *Service) createSVCInfoIfNotExist(p *lb.SVC) (*svcInfo, bool, bool,
 	prevSessionAffinity := false
 	prevLoadBalancerSourceRanges := []*cidr.CIDR{}
 
+	// when Cilium is upgraded to a version that supports service protocol differentiation, and such feature is
+	// enabled, we may end up in a situation where some existing services do not have the protocol set.
+	//
+	// As in such cases we want to preserve the existing services (in order to not break existing connections to
+	// those services), when trying to create a new one check first if an "old" service without the protocol
+	// already exists, by overwriting its protocol to NONE.
+	// If it doesn't then do a second lookup in the svcByHash map with the protocol set.
+	//
+	// Note that this logic can be removed once we stop supporting services without protocol.
+	proto := p.Frontend.L3n4Addr.L4Addr.Protocol
+	p.Frontend.L3n4Addr.L4Addr.Protocol = "NONE"
+
+	backendProtos := []lb.L4Type{}
+	for _, backend := range p.Backends {
+		backendProtos = append(backendProtos, backend.L3n4Addr.L4Addr.Protocol)
+		backend.L3n4Addr.L4Addr.Protocol = "NONE"
+	}
+
 	hash := p.Frontend.Hash()
 	svc, found := s.svcByHash[hash]
+	if !found {
+		p.Frontend.L3n4Addr.L4Addr.Protocol = proto
+		for i, backend := range p.Backends {
+			backend.L3n4Addr.L4Addr.Protocol = backendProtos[i]
+		}
+
+		hash = p.Frontend.Hash()
+		svc, found = s.svcByHash[hash]
+	}
+
 	if !found {
 		// Allocate service ID for the new service
 		addrID, err := AcquireID(p.Frontend.L3n4Addr, uint32(p.Frontend.ID))

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -32,6 +33,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service/healthserver"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 const anyPort = "*"
@@ -818,7 +820,7 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 		}
 		be.State = updatedB.State
 		be.Preferred = updatedB.Preferred
-
+	nextService:
 		for id, info := range s.svcByID {
 			var p *datapathTypes.UpsertServiceParams
 			for i, b := range info.backends {
@@ -833,10 +835,17 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 				found := false
 
 				if p, found = updateSvcs[id]; !found {
+					proto, err := u8proto.ParseProtocol(info.frontend.L4Addr.Protocol)
+					if err != nil {
+						errs = errors.Join(errs, fmt.Errorf("failed to parse service protocol for frontend %+v: %w", info.frontend, err))
+						continue nextService
+					}
+
 					p = &datapathTypes.UpsertServiceParams{
 						ID:                        uint16(id),
 						IP:                        info.frontend.L3n4Addr.AddrCluster.AsNetIP(),
 						Port:                      info.frontend.L3n4Addr.L4Addr.Port,
+						Protocol:                  byte(proto),
 						PrevBackendsCount:         len(info.backends),
 						IPv6:                      info.frontend.IsIPv6(),
 						Type:                      info.svcType,
@@ -1357,11 +1366,16 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 		}
 	}
 	svc.svcNatPolicy = natPolicy
+	protocol, err := u8proto.ParseProtocol(svc.frontend.L3n4Addr.L4Addr.Protocol)
+	if err != nil {
+		return err
+	}
 
 	p := &datapathTypes.UpsertServiceParams{
 		ID:                        uint16(svc.frontend.ID),
 		IP:                        svc.frontend.L3n4Addr.AddrCluster.AsNetIP(),
 		Port:                      svc.frontend.L3n4Addr.L4Addr.Port,
+		Protocol:                  uint8(protocol),
 		PreferredBackends:         preferredBackends,
 		ActiveBackends:            activeBackends,
 		NonActiveBackends:         nonActiveBackends,

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 type LBMockMap struct {
@@ -59,7 +60,11 @@ func (m *LBMockMap) UpsertService(p *datapathTypes.UpsertServiceParams) error {
 	}
 	svc, found := m.ServiceByID[p.ID]
 	if !found {
-		frontend := lb.NewL3n4AddrID(lb.NONE, cmtypes.MustAddrClusterFromIP(p.IP), p.Port, p.Scope, lb.ID(p.ID))
+		u8p, err := u8proto.FromNumber(p.Protocol)
+		if err != nil {
+			return err
+		}
+		frontend := lb.NewL3n4AddrID(u8p.String(), cmtypes.MustAddrClusterFromIP(p.IP), p.Port, p.Scope, lb.ID(p.ID))
 		svc = &lb.SVC{Frontend: *frontend}
 	} else {
 		if p.PrevBackendsCount != len(svc.Backends) {
@@ -137,7 +142,7 @@ func (m *LBMockMap) UpdateBackendWithState(b *lb.Backend) error {
 	if !found {
 		return fmt.Errorf("update failed : backend %d doesn't exist", id)
 	}
-	if b.ID != be.ID || b.Port != be.Port || !b.AddrCluster.Equal(be.AddrCluster) {
+	if b.ID != be.ID || b.Port != be.Port || b.Protocol != be.Protocol || !b.AddrCluster.Equal(be.AddrCluster) {
 		return fmt.Errorf("backend in the map  %+v doesn't match %+v: only backend"+
 			"state can be updated", be.String(), b.String())
 	}

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -34,6 +34,7 @@ var protoNames = map[U8proto]string{
 var ProtoIDs = map[string]U8proto{
 	"all":    0,
 	"any":    0,
+	"none":   0,
 	"icmp":   1,
 	"tcp":    6,
 	"udp":    17,
@@ -55,4 +56,12 @@ func ParseProtocol(proto string) (U8proto, error) {
 		return u, nil
 	}
 	return 0, fmt.Errorf("unknown protocol '%s'", proto)
+}
+
+func FromNumber(proto uint8) (U8proto, error) {
+	_, ok := protoNames[U8proto(proto)]
+	if !ok {
+		return 0, fmt.Errorf("unknown protocol %d", proto)
+	}
+	return U8proto(proto), nil
 }


### PR DESCRIPTION
git cherry-pick f8367055fd7aca1b6b95ae9b804a0e4d6f11c535, 0cf22cc3c3ffa15e8255da5093b043225bcac032, b25daf90b166ac148e98729d6113daddedbaee75, 45a84b4d4af64919a8bec5ded54626091e4e5d4e


Run `ARCH=amd64 DOCKER_REGISTRY=docker.io DOCKER_DEV_ACCOUNT=<docker account> DOCKER_IMAGE_TAG=v1.14.14-conformance-fix make docker-cilium-image docker-operator-generic-image` to build the image.