### PR TITLE
cherry-picks from upstream on v1.16.6 for conformance test fix

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,6 +49,7 @@ cilium-agent [flags]
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M) (default 16381)
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
       --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
+      --bpf-lb-proto-diff                                         Enable support for service protocol differentiation (TCP, UDP, SCTP) (default true)
       --bpf-lb-rss-ipv4-src-cidr string                           BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP
       --bpf-lb-rss-ipv6-src-cidr string                           BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic

--- a/Documentation/cmdref/cilium-dbg_service_update.md
+++ b/Documentation/cmdref/cilium-dbg_service_update.md
@@ -24,6 +24,7 @@ cilium-dbg service update [flags]
       --k8s-load-balancer               Set service as a k8s LoadBalancer
       --k8s-node-port                   Set service as a k8s NodePort
       --local-redirect                  Set service as Local Redirect
+      --protocol string                 Protocol for service (e.g. TCP, UDP) (default "tcp")
       --states strings                  Backend state(s) as {active(default),terminating,quarantined,maintenance}
 ```
 

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -242,14 +242,14 @@ In this example, services with port ``31940`` were created (one for each of devi
     $ kubectl -n kube-system exec ds/cilium -- cilium-dbg service list
     ID   Frontend               Service Type   Backend
     [...]
-    4    10.104.239.135:80      ClusterIP      1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    5    0.0.0.0:31940          NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    6    192.168.178.29:31940   NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
-    7    172.16.0.29:31940      NodePort       1 => 10.217.0.107:80
-                                               2 => 10.217.0.149:80
+    4    10.104.239.135:80/TCP      ClusterIP      1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    5    0.0.0.0:31940/TCP          NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    6    192.168.178.29:31940/TCP   NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
+    7    172.16.0.29:31940/TCP      NodePort       1 => 10.217.0.107:80/TCP
+                                                   2 => 10.217.0.149:80/TCP
 
 Create a variable with the node port for testing:
 

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -37,6 +37,9 @@ type BackendAddress struct {
 	// on related annotation of global service. Applicable for active state only.
 	Preferred bool `json:"preferred,omitempty"`
 
+	// Layer 4 protocol (TCP, UDP, etc)
+	Protocol string `json:"protocol,omitempty"`
+
 	// State of the backend for load-balancing service traffic
 	// Enum: ["active","terminating","quarantined","maintenance"]
 	State string `json:"state,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2964,6 +2964,9 @@ definitions:
       ip:
         description: Layer 3 address
         type: string
+      protocol:
+        description: Layer 4 protocol (TCP, UDP, etc)
+        type: string
       port:
         description: Layer 4 port number
         type: integer

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1909,6 +1909,10 @@ func init() {
           "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
           "type": "boolean"
         },
+        "protocol": {
+          "description": "Layer 4 protocol (TCP, UDP, etc)",
+          "type": "string"
+        },
         "state": {
           "description": "State of the backend for load-balancing service traffic",
           "type": "string",
@@ -7583,6 +7587,10 @@ func init() {
         "preferred": {
           "description": "Indicator if this backend is preferred in the context of clustermesh service affinity. The value is set based\non related annotation of global service. Applicable for active state only.",
           "type": "boolean"
+        },
+        "protocol": {
+          "description": "Layer 4 protocol (TCP, UDP, etc)",
+          "type": "string"
         },
         "state": {
           "description": "State of the backend for load-balancing service traffic",

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -41,6 +41,9 @@ static __always_inline __maybe_unused bool is_v6_loopback(const union v6addr *da
 }
 
 /* Hack due to missing narrow ctx access. */
+#define ctx_protocol(__ctx) ((__u8)(volatile __u32)(__ctx)->protocol)
+
+/* Hack due to missing narrow ctx access. */
 static __always_inline __maybe_unused __be16
 ctx_dst_port(const struct bpf_sock_addr *ctx)
 {
@@ -105,12 +108,12 @@ bool sock_is_health_check(struct bpf_sock_addr *ctx __maybe_unused)
 static __always_inline __maybe_unused
 __u64 sock_select_slot(struct bpf_sock_addr *ctx)
 {
-	return ctx->protocol == IPPROTO_TCP ?
+	return ctx_protocol(ctx) == IPPROTO_TCP ?
 	       get_prandom_u32() : sock_local_cookie(ctx);
 }
 
 static __always_inline __maybe_unused
-bool sock_proto_enabled(__u32 proto)
+bool sock_proto_enabled(__u8 proto)
 {
 	switch (proto) {
 	case IPPROTO_TCP:
@@ -245,10 +248,12 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb4_backend *backend;
 	struct lb4_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	__u32 dst_ip = ctx->user_ip4;
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
+		.proto		= protocol,
 	}, orig_key = key;
 	struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -260,7 +265,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(protocol))
 		return -ENOTSUP;
 
 	/* In case a direct match fails, we try to look-up surrogate
@@ -268,8 +273,13 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * HostPort services.
 	 */
 	svc = lb4_lookup_service(&key, true);
-	if (!svc)
+	if (!svc) {
+		/* Restore the original key's protocol as lb4_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
+	}
 	if (!svc)
 		return -ENXIO;
 	if (svc->count == 0 && !lb4_svc_is_l7loadbalancer(svc))
@@ -433,23 +443,30 @@ int cil_sock4_connect(struct bpf_sock_addr *ctx)
 static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 					     struct bpf_sock *ctx_full)
 {
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb4_service *svc;
 	struct lb4_key key = {
 		.address	= ctx->src_ip4,
 		.dport		= ctx_src_port(ctx),
+		.proto		= protocol,
 	};
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(protocol) ||
 	    !ctx_in_hostns(ctx_full, NULL))
 		return 0;
 
 	svc = lb4_lookup_service(&key, true);
-	if (!svc)
+	if (!svc) {
 		/* Perform a wildcard lookup for the case where the caller
 		 * tries to bind to loopback or an address with host identity
 		 * (without remote hosts).
+		 *
+		 * Restore the original key's protocol as lb4_lookup_service
+		 * has overwritten it.
 		 */
+		key.proto = protocol;
 		svc = sock4_wildcard_lookup(&key, false, false, true);
+	}
 
 	/* If the sockaddr of this socket overlaps with a NodePort,
 	 * LoadBalancer or ExternalIP service. We must reject this
@@ -496,7 +513,7 @@ static __always_inline int __sock4_pre_bind(struct bpf_sock_addr *ctx,
 		.peer = {
 			.address	= ctx->user_ip4,
 			.port		= ctx_dst_port(ctx),
-			.proto		= (__u8)ctx->protocol,
+			.proto		= ctx_protocol(ctx),
 		},
 	};
 	int ret;
@@ -512,7 +529,7 @@ int cil_sock4_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(ctx_protocol(ctx)) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return ret;
 	if (sock_is_health_check(ctx) &&
@@ -529,6 +546,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 {
 	struct ipv4_revnat_entry *val;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	__u32 dst_ip = ctx->user_ip4;
 	struct ipv4_revnat_tuple key = {
 		.cookie		= sock_local_cookie(ctx_full),
@@ -544,12 +562,18 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		struct lb4_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= protocol,
 		};
 
 		svc = lb4_lookup_service(&svc_key, true);
-		if (!svc)
+		if (!svc) {
+			/* Restore the original key's protocol as lb4_lookup_service
+			 * has overwritten it.
+			 */
+			svc_key.proto = protocol;
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
+		}
 		if (!svc || svc->rev_nat_index != val->rev_nat_index ||
 		    (svc->count == 0 && !lb4_svc_is_l7loadbalancer(svc))) {
 			map_delete_elem(&LB4_REVERSE_NAT_SK_MAP, &key);
@@ -769,7 +793,7 @@ int sock6_xlate_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused,
 		return -ENXIO;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -799,7 +823,7 @@ sock6_post_bind_v4_in_v6(struct bpf_sock *ctx __maybe_unused)
 		return 0;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol = ctx->protocol;
+	fake_ctx.protocol = ctx_protocol(ctx);
 	fake_ctx.src_ip4  = addr6.p4;
 	fake_ctx.src_port = ctx->src_port;
 
@@ -810,12 +834,14 @@ sock6_post_bind_v4_in_v6(struct bpf_sock *ctx __maybe_unused)
 
 static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 {
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_service *svc;
 	struct lb6_key key = {
 		.dport		= ctx_src_port(ctx),
+		.proto		= protocol,
 	};
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(protocol) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return 0;
 
@@ -823,6 +849,10 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	svc = lb6_lookup_service(&key, true);
 	if (!svc) {
+		/* Restore the original key's protocol as lb6_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
 			return sock6_post_bind_v4_in_v6(ctx);
@@ -863,7 +893,7 @@ sock6_pre_bind_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 	ctx_get_v6_address(ctx, &addr6);
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -894,7 +924,7 @@ static __always_inline int __sock6_pre_bind(struct bpf_sock_addr *ctx)
 	struct lb6_health val = {
 		.peer = {
 			.port		= ctx_dst_port(ctx),
-			.proto		= (__u8)ctx->protocol,
+			.proto		= ctx_protocol(ctx),
 		},
 	};
 	int ret = 0;
@@ -916,7 +946,7 @@ int cil_sock6_pre_bind(struct bpf_sock_addr *ctx)
 {
 	int ret = SYS_PROCEED;
 
-	if (!sock_proto_enabled(ctx->protocol) ||
+	if (!sock_proto_enabled(ctx_protocol(ctx)) ||
 	    !ctx_in_hostns(ctx, NULL))
 		return ret;
 	if (sock_is_health_check(ctx) &&
@@ -937,8 +967,10 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb6_backend *backend;
 	struct lb6_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_key key = {
 		.dport		= dst_port,
+		.proto		= protocol,
 	}, orig_key;
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -950,15 +982,20 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (is_defined(ENABLE_SOCKET_LB_HOST_ONLY) && !in_hostns)
 		return -ENXIO;
 
-	if (!udp_only && !sock_proto_enabled(ctx->protocol))
+	if (!udp_only && !sock_proto_enabled(protocol))
 		return -ENOTSUP;
 
 	ctx_get_v6_address(ctx, &key.address);
 	memcpy(&orig_key, &key, sizeof(key));
 
 	svc = lb6_lookup_service(&key, true);
-	if (!svc)
+	if (!svc) {
+		/* Restore the original key's protocol as lb6_lookup_service
+		 * has overwritten it.
+		 */
+		key.proto = protocol;
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
+	}
 	if (!svc)
 		return sock6_xlate_v4_in_v6(ctx, udp_only);
 	if (svc->count == 0 && !lb6_svc_is_l7loadbalancer(svc))
@@ -1114,7 +1151,7 @@ sock6_xlate_rev_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 		return -ENXIO;
 
 	memset(&fake_ctx, 0, sizeof(fake_ctx));
-	fake_ctx.protocol  = ctx->protocol;
+	fake_ctx.protocol  = ctx_protocol(ctx);
 	fake_ctx.user_ip4  = addr6.p4;
 	fake_ctx.user_port = ctx_dst_port(ctx);
 
@@ -1137,6 +1174,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 	struct ipv6_revnat_tuple key = {};
 	struct ipv6_revnat_entry *val;
 	__u16 dst_port = ctx_dst_port(ctx);
+	__u8 protocol = ctx_protocol(ctx);
 
 	key.cookie = sock_local_cookie(ctx);
 	key.port = dst_port;
@@ -1151,12 +1189,18 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		struct lb6_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+			.proto		= protocol,
 		};
 
 		svc = lb6_lookup_service(&svc_key, true);
-		if (!svc)
+		if (!svc) {
+			/* Restore the original key's protocol as lb6_lookup_service
+			 * has overwritten it.
+			 */
+			svc_key.proto = protocol;
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));
+		}
 		if (!svc || svc->rev_nat_index != val->rev_nat_index ||
 		    (svc->count == 0 && !lb6_svc_is_l7loadbalancer(svc))) {
 			map_delete_elem(&LB6_REVERSE_NAT_SK_MAP, &key);

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -253,7 +253,9 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	}, orig_key = key;
 	struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -277,7 +279,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 		/* Restore the original key's protocol as lb4_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb4_key_set_protocol(&key, protocol);
 		svc = sock4_wildcard_lookup_full(&key, in_hostns);
 	}
 	if (!svc)
@@ -448,7 +450,9 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 	struct lb4_key key = {
 		.address	= ctx->src_ip4,
 		.dport		= ctx_src_port(ctx),
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	};
 
 	if (!sock_proto_enabled(protocol) ||
@@ -464,7 +468,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 		 * Restore the original key's protocol as lb4_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb4_key_set_protocol(&key, protocol);
 		svc = sock4_wildcard_lookup(&key, false, false, true);
 	}
 
@@ -562,7 +566,9 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 		struct lb4_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 			.proto		= protocol,
+#endif
 		};
 
 		svc = lb4_lookup_service(&svc_key, true);
@@ -570,7 +576,7 @@ static __always_inline int __sock4_xlate_rev(struct bpf_sock_addr *ctx,
 			/* Restore the original key's protocol as lb4_lookup_service
 			 * has overwritten it.
 			 */
-			svc_key.proto = protocol;
+			lb4_key_set_protocol(&svc_key, protocol);
 			svc = sock4_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx_full, NULL));
 		}
@@ -838,7 +844,9 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 	struct lb6_service *svc;
 	struct lb6_key key = {
 		.dport		= ctx_src_port(ctx),
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	};
 
 	if (!sock_proto_enabled(protocol) ||
@@ -852,7 +860,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 		/* Restore the original key's protocol as lb6_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb6_key_set_protocol(&key, protocol);
 		svc = sock6_wildcard_lookup(&key, false, false, true);
 		if (!svc)
 			return sock6_post_bind_v4_in_v6(ctx);
@@ -970,7 +978,9 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	__u8 protocol = ctx_protocol(ctx);
 	struct lb6_key key = {
 		.dport		= dst_port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 		.proto		= protocol,
+#endif
 	}, orig_key;
 	struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
@@ -993,7 +1003,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		/* Restore the original key's protocol as lb6_lookup_service
 		 * has overwritten it.
 		 */
-		key.proto = protocol;
+		lb6_key_set_protocol(&key, protocol);
 		svc = sock6_wildcard_lookup_full(&key, in_hostns);
 	}
 	if (!svc)
@@ -1189,7 +1199,9 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 		struct lb6_key svc_key = {
 			.address	= val->address,
 			.dport		= val->port,
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
 			.proto		= protocol,
+#endif
 		};
 
 		svc = lb6_lookup_service(&svc_key, true);
@@ -1197,7 +1209,7 @@ static __always_inline int __sock6_xlate_rev(struct bpf_sock_addr *ctx)
 			/* Restore the original key's protocol as lb6_lookup_service
 			 * has overwritten it.
 			 */
-			svc_key.proto = protocol;
+			lb6_key_set_protocol(&svc_key, protocol);
 			svc = sock6_wildcard_lookup_full(&svc_key,
 						ctx_in_hostns(ctx, NULL));
 		}

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -997,7 +997,7 @@ struct lb6_key {
 	union v6addr address;	/* Service virtual IPv6 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };
@@ -1056,7 +1056,7 @@ struct lb4_key {
 	__be32 address;		/* Service virtual IPv4 address */
 	__be16 dport;		/* L4 port filter, if unset, all ports apply */
 	__u16 backend_slot;	/* Backend iterator, 0 indicates the svc frontend */
-	__u8 proto;		/* L4 protocol, currently not used (set to 0) */
+	__u8 proto;		/* L4 protocol, 0 indicates any protocol */
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -639,6 +639,15 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key,
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
 	svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	/* If there are no elements for a specific protocol, check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
+	}
+#endif
+
 	if (svc) {
 		if (!scope_switch || !lb6_svc_is_two_scopes(svc))
 			return svc;
@@ -1310,6 +1319,15 @@ struct lb4_service *lb4_lookup_service(struct lb4_key *key,
 	key->scope = LB_LOOKUP_SCOPE_EXT;
 	key->backend_slot = 0;
 	svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	/* If there are no elements for a specific protocol, check for ANY entries. */
+	if (!svc && key->proto != 0) {
+		key->proto = 0;
+		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
+	}
+#endif
+
 	if (svc) {
 		if (!scope_switch || !lb4_svc_is_two_scopes(svc))
 			return svc;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -525,9 +525,18 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 }
 
 static __always_inline void
+lb6_key_set_protocol(struct lb6_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	key->proto = protocol;
+#endif
+}
+
+static __always_inline void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
-	key->proto = tuple->nexthdr;
+	lb6_key_set_protocol(key, tuple->nexthdr);
 	ipv6_addr_copy(&key->address, &tuple->daddr);
 	key->dport = tuple->sport;
 }
@@ -1073,6 +1082,12 @@ struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused,
 	return NULL;
 }
 
+static __always_inline void
+lb6_key_set_protocol(struct lb6_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+}
+
 static __always_inline
 struct lb6_service *__lb6_lookup_backend_slot(struct lb6_key *key __maybe_unused)
 {
@@ -1191,9 +1206,18 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 }
 
 static __always_inline void
+lb4_key_set_protocol(struct lb4_key *key __maybe_unused,
+		     __u8 protocol __maybe_unused)
+{
+#if defined(ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION)
+	key->proto = protocol;
+#endif
+}
+
+static __always_inline void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
-	key->proto = tuple->nexthdr;
+	lb4_key_set_protocol(key, tuple->nexthdr);
 	key->address = tuple->daddr;
 	/* CT tuple has ports in reverse order: */
 	key->dport = tuple->sport;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -527,8 +527,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 static __always_inline void
 lb6_fill_key(struct lb6_key *key, struct ipv6_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	ipv6_addr_copy(&key->address, &tuple->daddr);
 	key->dport = tuple->sport;
 }
@@ -1194,8 +1193,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 static __always_inline void
 lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
-	/* FIXME: set after adding support for different L4 protocols in LB */
-	key->proto = 0;
+	key->proto = tuple->nexthdr;
 	key->address = tuple->daddr;
 	/* CT tuple has ports in reverse order: */
 	key->dport = tuple->sport;

--- a/cilium-dbg/cmd/bpf_lb_list.go
+++ b/cilium-dbg/cmd/bpf_lb_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 const (
@@ -105,12 +106,12 @@ func dumpSVC(serviceList map[string][]string) {
 		} else if backend, found := backendMap[backendID]; !found {
 			entry = fmt.Sprintf("backend %d not found", backendID)
 		} else {
-			fmtStr := "%s:%d (%d) (%d)"
+			fmtStr := "%s:%d/%s (%d) (%d)"
 			if svcKey.IsIPv6() {
-				fmtStr = "[%s]:%d (%d) (%d)"
+				fmtStr = "[%s]:%d/%s (%d) (%d)"
 			}
 			entry = fmt.Sprintf(fmtStr, backend.GetAddress(),
-				backend.GetPort(), revNATID, backendSlot)
+				backend.GetPort(), u8proto.U8proto(backend.GetProtocol()).String(), revNATID, backendSlot)
 		}
 
 		serviceList[svc] = append(serviceList[svc], entry)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -610,6 +610,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	option.BindEnv(vp, option.LoadBalancerAcceleration)
 
+	flags.Bool(option.LoadBalancerProtocolDifferentiation, true, "Enable support for service protocol differentiation (TCP, UDP, SCTP)")
+	option.BindEnv(vp, option.LoadBalancerProtocolDifferentiation)
+
 	flags.Uint(option.MaglevTableSize, maglev.DefaultTableSize, "Maglev per service backend table size (parameter M)")
 	option.BindEnv(vp, option.MaglevTableSize)
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -777,6 +777,9 @@ data:
 {{- if hasKey .Values.loadBalancer "serviceTopology" }}
   enable-service-topology: {{ .Values.loadBalancer.serviceTopology | quote }}
 {{- end }}
+{{- if hasKey .Values.loadBalancer "protocolDifferentiation" }}
+  bpf-lb-proto-diff: {{ .Values.loadBalancer.protocolDifferentiation.enabled | quote }}
+{{- end }}
 
 {{- end }}
 {{- if hasKey .Values.maglev "tableSize" }}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -514,6 +514,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = "128"
 			}
 		}
+
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
 		}
@@ -775,6 +776,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	// Write Identity and ClusterID related macros.
 	cDefinesMap["CLUSTER_ID_MAX"] = fmt.Sprintf("%d", option.Config.MaxConnectedClusters)
+
+	if option.Config.LoadBalancerProtocolDifferentiation {
+		cDefinesMap["ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION"] = "1"
+	}
 
 	fmt.Fprint(fw, declareConfig("identity_length", identity.GetClusterIDShift(), "Identity length in bits"))
 	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))

--- a/pkg/datapath/types/lbmap.go
+++ b/pkg/datapath/types/lbmap.go
@@ -31,9 +31,10 @@ type LBMap interface {
 }
 
 type UpsertServiceParams struct {
-	ID   uint16
-	IP   net.IP
-	Port uint16
+	ID       uint16
+	IP       net.IP
+	Port     uint16
+	Protocol uint8
 
 	// PreferredBackends is a subset of ActiveBackends
 	// Note: this is only used in clustermesh with service affinity annotation.

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -540,13 +540,10 @@ func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRa
 }
 
 // UniquePorts returns a map of all unique ports configured in the service
-func (s *Service) UniquePorts() map[uint16]bool {
-	// We are not discriminating the different L4 protocols on the same L4
-	// port so we create the number of unique sets of service IP + service
-	// port.
-	uniqPorts := map[uint16]bool{}
+func (s *Service) UniquePorts() map[string]bool {
+	uniqPorts := map[string]bool{}
 	for _, p := range s.Ports {
-		uniqPorts[p.Port] = true
+		uniqPorts[p.String()] = true
 	}
 	return uniqPorts
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -219,10 +219,10 @@ func (k *K8sServiceWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service) 
 	frontends := []*loadbalancer.L3n4Addr{}
 
 	for portName, svcPort := range svcInfo.Ports {
-		if !repPorts[svcPort.Port] {
+		if !repPorts[svcPort.String()] {
 			continue
 		}
-		repPorts[svcPort.Port] = false
+		repPorts[svcPort.String()] = false
 
 		for _, feIP := range svcInfo.FrontendIPs {
 			fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
@@ -357,10 +357,10 @@ func datapathSVCs(svc *k8s.Service, endpoints *k8s.Endpoints) (svcs []loadbalanc
 
 	clusterIPPorts := map[loadbalancer.FEPortName]*loadbalancer.L4Addr{}
 	for fePortName, fePort := range svc.Ports {
-		if !uniqPorts[fePort.Port] {
+		if !uniqPorts[fePort.String()] {
 			continue
 		}
-		uniqPorts[fePort.Port] = false
+		uniqPorts[fePort.String()] = false
 		clusterIPPorts[fePortName] = fePort
 	}
 

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -214,51 +214,57 @@ func (k *K8sServiceWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service) 
 		logfields.K8sNamespace: svc.Namespace,
 	})
 
-	repPorts := svcInfo.UniquePorts()
-
-	frontends := []*loadbalancer.L3n4Addr{}
-
-	for portName, svcPort := range svcInfo.Ports {
-		if !repPorts[svcPort.String()] {
-			continue
-		}
-		repPorts[svcPort.String()] = false
-
-		for _, feIP := range svcInfo.FrontendIPs {
-			fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
-			frontends = append(frontends, fe)
+	for _, checkProtocol := range []bool{true, false} {
+		if !checkProtocol {
+			svcInfo = stripServiceProtocol(svcInfo)
 		}
 
-		for _, nodePortFE := range svcInfo.NodePorts[portName] {
-			frontends = append(frontends, &nodePortFE.L3n4Addr)
-			if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
-				cpFE := nodePortFE.L3n4Addr.DeepCopy()
-				cpFE.Scope = loadbalancer.ScopeInternal
-				frontends = append(frontends, cpFE)
+		repPorts := svcInfo.UniquePorts()
+
+		frontends := []*loadbalancer.L3n4Addr{}
+
+		for portName, svcPort := range svcInfo.Ports {
+			if !repPorts[svcPort.String()] {
+				continue
+			}
+			repPorts[svcPort.String()] = false
+
+			for _, feIP := range svcInfo.FrontendIPs {
+				fe := loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(feIP), svcPort.Port, loadbalancer.ScopeExternal)
+				frontends = append(frontends, fe)
+			}
+
+			for _, nodePortFE := range svcInfo.NodePorts[portName] {
+				frontends = append(frontends, &nodePortFE.L3n4Addr)
+				if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+					cpFE := nodePortFE.L3n4Addr.DeepCopy()
+					cpFE.Scope = loadbalancer.ScopeInternal
+					frontends = append(frontends, cpFE)
+				}
+			}
+
+			for _, k8sExternalIP := range svcInfo.K8sExternalIPs {
+				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(k8sExternalIP), svcPort.Port, loadbalancer.ScopeExternal))
+			}
+
+			for _, ip := range svcInfo.LoadBalancerIPs {
+				addrCluster := cmtypes.MustAddrClusterFromIP(ip)
+				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeExternal))
+				if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+					frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeInternal))
+				}
 			}
 		}
 
-		for _, k8sExternalIP := range svcInfo.K8sExternalIPs {
-			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, cmtypes.MustAddrClusterFromIP(k8sExternalIP), svcPort.Port, loadbalancer.ScopeExternal))
-		}
-
-		for _, ip := range svcInfo.LoadBalancerIPs {
-			addrCluster := cmtypes.MustAddrClusterFromIP(ip)
-			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeExternal))
-			if svcInfo.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal || svcInfo.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
-				frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, addrCluster, svcPort.Port, loadbalancer.ScopeInternal))
+		for _, fe := range frontends {
+			if found, err := k.svcManager.DeleteService(*fe); err != nil {
+				scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
+					Warn("Error deleting service by frontend")
+			} else if !found {
+				scopedLog.WithField(logfields.Object, logfields.Repr(fe)).Warn("service not found")
+			} else {
+				scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.AddrCluster.String(), fe.Port)
 			}
-		}
-	}
-
-	for _, fe := range frontends {
-		if found, err := k.svcManager.DeleteService(*fe); err != nil {
-			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
-				Warn("Error deleting service by frontend")
-		} else if !found {
-			scopedLog.WithField(logfields.Object, logfields.Repr(fe)).Warn("service not found")
-		} else {
-			scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.AddrCluster.String(), fe.Port)
 		}
 	}
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -435,12 +435,12 @@ func stripServiceProtocol(svc *k8s.Service) *k8s.Service {
 	svc = svc.DeepCopy()
 
 	for _, port := range svc.Ports {
-		port.Protocol = "NONE"
+		port.Protocol = "ANY"
 	}
 
 	for _, nodePort := range svc.NodePorts {
 		for _, port := range nodePort {
-			port.Protocol = "NONE"
+			port.Protocol = "ANY"
 		}
 	}
 
@@ -452,7 +452,7 @@ func stripEndpointsProtocol(endpoints *k8s.Endpoints) *k8s.Endpoints {
 
 	for _, backend := range endpoints.Backends {
 		for _, port := range backend.Ports {
-			port.Protocol = "NONE"
+			port.Protocol = "ANY"
 		}
 	}
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -233,6 +233,8 @@ func (s ServiceFlags) UInt16() uint16 {
 const (
 	// NONE type.
 	NONE = L4Type("NONE")
+	// ANY type.
+	ANY = L4Type("ANY")
 	// TCP type.
 	TCP = L4Type("TCP")
 	// UDP type.
@@ -530,6 +532,8 @@ func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
 	case "none":
 		return NONE, nil
+	case "any":
+		return ANY, nil
 	case "tcp":
 		return TCP, nil
 	case "udp":
@@ -550,7 +554,7 @@ func NewL4TypeFromNumber(proto uint8) L4Type {
 	case 132:
 		return SCTP
 	default:
-		return NONE
+		return ANY
 	}
 }
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -528,6 +528,8 @@ func IsValidBackendState(state string) bool {
 
 func NewL4Type(name string) (L4Type, error) {
 	switch strings.ToLower(name) {
+	case "none":
+		return NONE, nil
 	case "tcp":
 		return TCP, nil
 	case "udp":

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // SVCType is a type of a service.
@@ -230,6 +231,7 @@ func (s ServiceFlags) UInt16() uint16 {
 }
 
 const (
+	// NONE type.
 	NONE = L4Type("NONE")
 	// TCP type.
 	TCP = L4Type("TCP")
@@ -537,6 +539,19 @@ func NewL4Type(name string) (L4Type, error) {
 	}
 }
 
+func NewL4TypeFromNumber(proto uint8) L4Type {
+	switch proto {
+	case 6:
+		return TCP
+	case 17:
+		return UDP
+	case 132:
+		return SCTP
+	default:
+		return NONE
+	}
+}
+
 // L4Addr is an abstraction for the backend port with a L4Type, usually tcp or udp, and
 // the Port number.
 //
@@ -558,6 +573,22 @@ func (l *L4Addr) DeepEqual(o *L4Addr) bool {
 // NewL4Addr creates a new L4Addr.
 func NewL4Addr(protocol L4Type, number uint16) *L4Addr {
 	return &L4Addr{Protocol: protocol, Port: number}
+}
+
+// Equals returns true if both L4Addr are considered equal.
+func (l *L4Addr) Equals(o *L4Addr) bool {
+	switch {
+	case (l == nil) != (o == nil):
+		return false
+	case (l == nil) && (o == nil):
+		return true
+	}
+	return l.Port == o.Port && l.Protocol == o.Protocol
+}
+
+// String returns a string representation of an L4Addr
+func (l *L4Addr) String() string {
+	return fmt.Sprintf("%d/%s", l.Port, l.Protocol)
 }
 
 // L3n4Addr is used to store, as an unique L3+L4 address in the KVStore. It also
@@ -653,8 +684,7 @@ func NewBackendFromBackendModel(base *models.BackendAddress) (*Backend, error) {
 		return nil, fmt.Errorf("missing IP address")
 	}
 
-	// FIXME: Should this be NONE ?
-	l4addr := NewL4Addr(NONE, base.Port)
+	l4addr := NewL4Addr(base.Protocol, base.Port)
 	addrCluster, err := cmtypes.ParseAddrCluster(*base.IP)
 	if err != nil {
 		return nil, err
@@ -688,8 +718,7 @@ func NewL3n4AddrFromBackendModel(base *models.BackendAddress) (*L3n4Addr, error)
 		return nil, fmt.Errorf("missing IP address")
 	}
 
-	// FIXME: Should this be NONE ?
-	l4addr := NewL4Addr(NONE, base.Port)
+	l4addr := NewL4Addr(base.Protocol, base.Port)
 	addrCluster, err := cmtypes.ParseAddrCluster(*base.IP)
 	if err != nil {
 		return nil, err
@@ -707,9 +736,10 @@ func (a *L3n4Addr) GetModel() *models.FrontendAddress {
 		scope = models.FrontendAddressScopeInternal
 	}
 	return &models.FrontendAddress{
-		IP:    a.AddrCluster.String(),
-		Port:  a.Port,
-		Scope: scope,
+		IP:       a.AddrCluster.String(),
+		Protocol: a.Protocol,
+		Port:     a.Port,
+		Scope:    scope,
 	}
 }
 
@@ -722,6 +752,7 @@ func (b *Backend) GetBackendModel() *models.BackendAddress {
 	stateStr, _ := b.State.String()
 	return &models.BackendAddress{
 		IP:        &addrClusterStr,
+		Protocol:  b.Protocol,
 		Port:      b.Port,
 		NodeName:  b.NodeName,
 		Zone:      option.Config.GetZone(b.ZoneID),
@@ -731,17 +762,10 @@ func (b *Backend) GetBackendModel() *models.BackendAddress {
 	}
 }
 
-// String returns the L3n4Addr in the "IPv4:Port[/Scope]" format for IPv4 and
-// "[IPv6]:Port[/Scope]" format for IPv6.
+// String returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]" format for IPv4 and
+// "[IPv6]:Port/Protocol[/Scope]" format for IPv6.
 func (a *L3n4Addr) String() string {
-	var scope string
-	if a.Scope == ScopeInternal {
-		scope = "/i"
-	}
-	if a.IsIPv6() {
-		return "[" + a.AddrCluster.String() + "]:" + strconv.FormatUint(uint64(a.Port), 10) + scope
-	}
-	return a.AddrCluster.String() + ":" + strconv.FormatUint(uint64(a.Port), 10) + scope
+	return a.StringWithProtocol()
 }
 
 // StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
@@ -759,8 +783,6 @@ func (a *L3n4Addr) StringWithProtocol() string {
 
 // StringID returns the L3n4Addr as string to be used for unique identification
 func (a *L3n4Addr) StringID() string {
-	// This does not include the protocol right now as the datapath does
-	// not include the protocol in the lookup of the service IP.
 	return a.String()
 }
 
@@ -768,14 +790,15 @@ func (a *L3n4Addr) StringID() string {
 // Note: the resulting string is meant to be used as a key for maps and is not
 // readable by a human eye when printed out.
 func (a L3n4Addr) Hash() string {
-	const lenProto = 0 // proto is omitted for now
+	const lenProto = 1 // proto is uint8
 	const lenScope = 1 // scope is uint8 which is an alias for byte
 	const lenPort = 2  // port is uint16 which is 2 bytes
 
 	b := make([]byte, cmtypes.AddrClusterLen+lenProto+lenScope+lenPort)
 	ac20 := a.AddrCluster.As20()
 	copy(b, ac20[:])
-	// FIXME: add Protocol once we care about protocols
+	u8p, _ := u8proto.ParseProtocol(a.Protocol)
+	b[net.IPv6len] = byte(u8p)
 	// scope is a uint8 which is an alias for byte so a cast is safe
 	b[net.IPv6len+lenProto] = byte(a.Scope)
 	// port is a uint16, so 2 bytes

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -250,6 +250,7 @@ func NewService4Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 func (k *Service4Key) String() string {
 	kHost := k.ToHost().(*Service4Key)
 	addr := net.JoinHostPort(kHost.Address.String(), fmt.Sprintf("%d", kHost.Port))
+	addr += fmt.Sprintf("/%s", u8proto.U8proto(kHost.Proto).String())
 	if kHost.Scope == loadbalancer.ScopeInternal {
 		addr += "/i"
 	}
@@ -268,6 +269,7 @@ func (k *Service4Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service4Key) GetScope() uint8         { return k.Scope }
 func (k *Service4Key) GetAddress() net.IP      { return k.Address.IP() }
 func (k *Service4Key) GetPort() uint16         { return k.Port }
+func (k *Service4Key) GetProtocol() uint8      { return k.Proto }
 func (k *Service4Key) MapDelete() error        { return k.Map().Delete(k.ToNetwork()) }
 
 func (k *Service4Key) RevNatValue() RevNatValue {
@@ -413,9 +415,10 @@ func (b *Backend4Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4Value) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), 0)
 }
-func (b *Backend4Value) GetPort() uint16 { return b.Port }
-func (b *Backend4Value) GetFlags() uint8 { return b.Flags }
-func (b *Backend4Value) GetZone() uint8  { return 0 }
+func (b *Backend4Value) GetPort() uint16    { return b.Port }
+func (b *Backend4Value) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend4Value) GetFlags() uint8    { return b.Flags }
+func (b *Backend4Value) GetZone() uint8     { return 0 }
 
 func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
@@ -481,9 +484,10 @@ func (b *Backend4ValueV3) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4ValueV3) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), uint32(b.ClusterID))
 }
-func (b *Backend4ValueV3) GetPort() uint16 { return b.Port }
-func (b *Backend4ValueV3) GetFlags() uint8 { return b.Flags }
-func (b *Backend4ValueV3) GetZone() uint8  { return b.Zone }
+func (b *Backend4ValueV3) GetPort() uint16    { return b.Port }
+func (b *Backend4ValueV3) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend4ValueV3) GetFlags() uint8    { return b.Flags }
+func (b *Backend4ValueV3) GetZone() uint8     { return b.Zone }
 
 func (v *Backend4ValueV3) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -150,9 +150,9 @@ func NewService6Key(ip net.IP, port uint16, proto u8proto.U8proto, scope uint8, 
 func (k *Service6Key) String() string {
 	kHost := k.ToHost().(*Service6Key)
 	if kHost.Scope == loadbalancer.ScopeInternal {
-		return fmt.Sprintf("[%s]:%d/i (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
+		return fmt.Sprintf("[%s]:%d/%s/i (%d)", kHost.Address, kHost.Port, u8proto.U8proto(kHost.Proto).String(), kHost.BackendSlot)
 	} else {
-		return fmt.Sprintf("[%s]:%d (%d)", kHost.Address, kHost.Port, kHost.BackendSlot)
+		return fmt.Sprintf("[%s]:%d/%s (%d)", kHost.Address, kHost.Port, u8proto.U8proto(kHost.Proto).String(), kHost.BackendSlot)
 	}
 }
 
@@ -167,6 +167,7 @@ func (k *Service6Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service6Key) GetScope() uint8         { return k.Scope }
 func (k *Service6Key) GetAddress() net.IP      { return k.Address.IP() }
 func (k *Service6Key) GetPort() uint16         { return k.Port }
+func (k *Service6Key) GetProtocol() uint8      { return k.Proto }
 func (k *Service6Key) MapDelete() error        { return k.Map().Delete(k.ToNetwork()) }
 
 func (k *Service6Key) RevNatValue() RevNatValue {
@@ -310,9 +311,10 @@ func (b *Backend6Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6Value) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), 0)
 }
-func (b *Backend6Value) GetPort() uint16 { return b.Port }
-func (b *Backend6Value) GetFlags() uint8 { return b.Flags }
-func (b *Backend6Value) GetZone() uint8  { return 0 }
+func (b *Backend6Value) GetPort() uint16    { return b.Port }
+func (b *Backend6Value) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend6Value) GetFlags() uint8    { return b.Flags }
+func (b *Backend6Value) GetZone() uint8     { return 0 }
 
 func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
@@ -378,9 +380,10 @@ func (b *Backend6ValueV3) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6ValueV3) GetIPCluster() cmtypes.AddrCluster {
 	return cmtypes.AddrClusterFrom(b.Address.Addr(), uint32(b.ClusterID))
 }
-func (b *Backend6ValueV3) GetPort() uint16 { return b.Port }
-func (b *Backend6ValueV3) GetFlags() uint8 { return b.Flags }
-func (b *Backend6ValueV3) GetZone() uint8  { return b.Zone }
+func (b *Backend6ValueV3) GetPort() uint16    { return b.Port }
+func (b *Backend6ValueV3) GetProtocol() uint8 { return uint8(b.Proto) }
+func (b *Backend6ValueV3) GetFlags() uint8    { return b.Flags }
+func (b *Backend6ValueV3) GetZone() uint8     { return b.Zone }
 
 func (v *Backend6ValueV3) ToNetwork() BackendValue {
 	n := *v

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -76,10 +75,10 @@ func (lbmap *LBBPFMap) upsertServiceProto(p *datapathTypes.UpsertServiceParams, 
 	backendsOk := ipv6 || !ipv6 && p.NatPolicy != loadbalancer.SVCNatPolicyNat46
 
 	if ipv6 {
-		svcKey = NewService6Key(p.IP, p.Port, u8proto.ANY, p.Scope, 0)
+		svcKey = NewService6Key(p.IP, p.Port, u8proto.U8proto(p.Protocol), p.Scope, 0)
 		svcVal = &Service6Value{}
 	} else {
-		svcKey = NewService4Key(p.IP, p.Port, u8proto.ANY, p.Scope, 0)
+		svcKey = NewService4Key(p.IP, p.Port, u8proto.U8proto(p.Protocol), p.Scope, 0)
 		svcVal = &Service4Value{}
 	}
 
@@ -200,11 +199,16 @@ func deleteServiceProto(svc loadbalancer.L3n4AddrID, backendCount int, useMaglev
 		revNATKey RevNatKey
 	)
 
+	u8p, err := u8proto.ParseProtocol(svc.Protocol)
+	if err != nil {
+		return err
+	}
+
 	if ipv6 {
-		svcKey = NewService6Key(svc.AddrCluster.AsNetIP(), svc.Port, u8proto.ANY, svc.Scope, 0)
+		svcKey = NewService6Key(svc.AddrCluster.AsNetIP(), svc.Port, u8p, svc.Scope, 0)
 		revNATKey = NewRevNat6Key(uint16(svc.ID))
 	} else {
-		svcKey = NewService4Key(svc.AddrCluster.AsNetIP(), svc.Port, u8proto.ANY, svc.Scope, 0)
+		svcKey = NewService4Key(svc.AddrCluster.AsNetIP(), svc.Port, u8p, svc.Scope, 0)
 		revNATKey = NewRevNat4Key(uint16(svc.ID))
 	}
 
@@ -452,11 +456,8 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 		if svcKey.GetBackendSlot() == 0 {
 			// Build a cache of flags stored in the value of the master key to
 			// map it later.
-			// FIXME proto is being ignored everywhere in the datapath.
-			addrStr := svcKey.GetAddress().String()
-			portStr := strconv.Itoa(int(svcKey.GetPort()))
-			flagsCache[net.JoinHostPort(addrStr, portStr)] = loadbalancer.ServiceFlags(svcValue.GetFlags())
 
+			flagsCache[fe.String()] = loadbalancer.ServiceFlags(svcValue.GetFlags())
 			newSVCMap.addFE(fe)
 			return
 		}
@@ -500,13 +501,11 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 	newSVCList := make([]*loadbalancer.SVC, 0, len(newSVCMap))
 	for hash := range newSVCMap {
 		svc := newSVCMap[hash]
-		addrStr := svc.Frontend.AddrCluster.String()
-		portStr := strconv.Itoa(int(svc.Frontend.Port))
-		host := net.JoinHostPort(addrStr, portStr)
-		svc.Type = flagsCache[host].SVCType()
-		svc.ExtTrafficPolicy = flagsCache[host].SVCExtTrafficPolicy()
-		svc.IntTrafficPolicy = flagsCache[host].SVCIntTrafficPolicy()
-		svc.NatPolicy = flagsCache[host].SVCNatPolicy(svc.Frontend.L3n4Addr)
+		key := svc.Frontend.String()
+		svc.Type = flagsCache[key].SVCType()
+		svc.ExtTrafficPolicy = flagsCache[key].SVCExtTrafficPolicy()
+		svc.IntTrafficPolicy = flagsCache[key].SVCIntTrafficPolicy()
+		svc.NatPolicy = flagsCache[key].SVCNatPolicy(svc.Frontend.L3n4Addr)
 		newSVCList = append(newSVCList, &svc)
 	}
 
@@ -544,7 +543,7 @@ func (*LBBPFMap) DumpBackendMaps() ([]*loadbalancer.Backend, error) {
 		ip := backendVal.GetAddress()
 		addrCluster := cmtypes.MustAddrClusterFromIP(ip)
 		port := backendVal.GetPort()
-		proto := loadbalancer.NONE
+		proto := loadbalancer.NewL4TypeFromNumber(backendVal.GetProtocol())
 		state := loadbalancer.GetBackendStateFromFlags(backendVal.GetFlags())
 		zone := backendVal.GetZone()
 		lbBackend := loadbalancer.NewBackendWithState(backendID, proto, addrCluster, port, zone, state)
@@ -610,11 +609,17 @@ func getBackend(backend *loadbalancer.Backend, ipv6 bool) (Backend, error) {
 		return lbBackend, fmt.Errorf("invalid backend ID 0")
 	}
 
+	u8p, err := u8proto.ParseProtocol(backend.Protocol)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse protocol lbBackend (%d, %s, %d, %s, %t): %w",
+			backend.ID, backend.AddrCluster.String(), backend.Port, backend.Protocol, ipv6, err)
+	}
+
 	if ipv6 {
-		lbBackend, err = NewBackend6V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
+		lbBackend, err = NewBackend6V3(backend.ID, backend.AddrCluster, backend.Port, u8p,
 			backend.State, backend.ZoneID)
 	} else {
-		lbBackend, err = NewBackend4V3(backend.ID, backend.AddrCluster, backend.Port, u8proto.ANY,
+		lbBackend, err = NewBackend4V3(backend.ID, backend.AddrCluster, backend.Port, u8p,
 			backend.State, backend.ZoneID)
 	}
 	if err != nil {

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
-// ServiceKey is the interface describing protocol independent key for services map v2.
+// ServiceKey is the interface describing key for services map v2.
 type ServiceKey interface {
 	bpf.MapKey
 
@@ -41,6 +41,9 @@ type ServiceKey interface {
 
 	// Get frontend port
 	GetPort() uint16
+
+	// Get protocol
+	GetProtocol() uint8
 
 	// Returns a RevNatValue matching a ServiceKey
 	RevNatValue() RevNatValue
@@ -113,7 +116,7 @@ type BackendKey interface {
 	GetID() loadbalancer.BackendID
 }
 
-// BackendValue is the interface describing protocol independent backend value.
+// BackendValue is the interface describing backend value.
 type BackendValue interface {
 	bpf.MapValue
 
@@ -125,6 +128,9 @@ type BackendValue interface {
 
 	// Get backend port
 	GetPort() uint16
+
+	// Get backend protocol
+	GetProtocol() uint8
 
 	// Get backend flags
 	GetFlags() uint8
@@ -180,7 +186,8 @@ type RevNatValue interface {
 func svcFrontend(svcKey ServiceKey, svcValue ServiceValue) *loadbalancer.L3n4AddrID {
 	feIP := svcKey.GetAddress()
 	feAddrCluster := cmtypes.MustAddrClusterFromIP(feIP)
-	feL3n4Addr := loadbalancer.NewL3n4Addr(loadbalancer.NONE, feAddrCluster, svcKey.GetPort(), svcKey.GetScope())
+	p := loadbalancer.NewL4TypeFromNumber(svcKey.GetProtocol())
+	feL3n4Addr := loadbalancer.NewL3n4Addr(p, feAddrCluster, svcKey.GetPort(), svcKey.GetScope())
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
 		ID:       loadbalancer.ID(svcValue.GetRevNat()),
@@ -192,7 +199,7 @@ func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbal
 	beIP := backend.GetAddress()
 	beAddrCluster := cmtypes.MustAddrClusterFromIP(beIP)
 	bePort := backend.GetPort()
-	beProto := loadbalancer.NONE
+	beProto := loadbalancer.NewL4TypeFromNumber(backend.GetProtocol())
 	beState := loadbalancer.GetBackendStateFromFlags(backend.GetFlags())
 	beZone := backend.GetZone()
 	beBackend := loadbalancer.NewBackendWithState(backendID, beProto, beAddrCluster, bePort, beZone, beState)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -280,6 +280,13 @@ const (
 	// Alias to NodePortAcceleration
 	LoadBalancerAcceleration = "bpf-lb-acceleration"
 
+	// LoadBalancerExternalControlPlane switch skips connectivity to kube-apiserver
+	// which is relevant in lb-only mode
+	LoadBalancerExternalControlPlane = "bpf-lb-external-control-plane"
+
+	// LoadBalancerProtocolDifferentiation enables support for service protocol differentiation (TCP, UDP, SCTP)
+	LoadBalancerProtocolDifferentiation = "bpf-lb-proto-diff"
+
 	// MaglevTableSize determines the size of the backend table per service
 	MaglevTableSize = "bpf-lb-maglev-table-size"
 
@@ -1958,6 +1965,13 @@ type DaemonConfig struct {
 	LoadBalancerRSSv6CIDR string
 	LoadBalancerRSSv6     net.IPNet
 
+	// LoadBalancerExternalControlPlane tells whether to not use kube-apiserver as
+	// its control plane in lb-only mode.
+	LoadBalancerExternalControlPlane bool
+
+	// LoadBalancerProtocolDifferentiation enables support for service protocol differentiation (TCP, UDP, SCTP)
+	LoadBalancerProtocolDifferentiation bool
+
 	// EnablePMTUDiscovery indicates whether to send ICMP fragmentation-needed
 	// replies to the client (when needed).
 	EnablePMTUDiscovery bool
@@ -3550,6 +3564,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	if c.KVStore != "" {
 		c.IdentityRestoreGracePeriod = defaults.IdentityRestoreGracePeriodKvstore
 	}
+
+	c.LoadBalancerProtocolDifferentiation = vp.GetBool(LoadBalancerProtocolDifferentiation)
 }
 
 func (c *DaemonConfig) populateLoadBalancerSettings(vp *viper.Viper) {

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -51,6 +51,7 @@ func NewIDAllocator(nextID uint32, maxID uint32) *IDAllocator {
 	}
 }
 
+// addID assumes the lock is held
 func (alloc *IDAllocator) addID(svc loadbalancer.L3n4Addr, id uint32) *loadbalancer.L3n4AddrID {
 	svcID := newID(svc, id)
 	alloc.entitiesID[id] = svcID

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1359,8 +1359,36 @@ func (s *Service) createSVCInfoIfNotExist(p *lb.SVC) (*svcInfo, bool, bool,
 	prevSessionAffinity := false
 	prevLoadBalancerSourceRanges := []*cidr.CIDR{}
 
+	// when Cilium is upgraded to a version that supports service protocol differentiation, and such feature is
+	// enabled, we may end up in a situation where some existing services do not have the protocol set.
+	//
+	// As in such cases we want to preserve the existing services (in order to not break existing connections to
+	// those services), when trying to create a new one check first if an "old" service without the protocol
+	// already exists, by overwriting its protocol to NONE.
+	// If it doesn't then do a second lookup in the svcByHash map with the protocol set.
+	//
+	// Note that this logic can be removed once we stop supporting services without protocol.
+	proto := p.Frontend.L3n4Addr.L4Addr.Protocol
+	p.Frontend.L3n4Addr.L4Addr.Protocol = "NONE"
+
+	backendProtos := []lb.L4Type{}
+	for _, backend := range p.Backends {
+		backendProtos = append(backendProtos, backend.L3n4Addr.L4Addr.Protocol)
+		backend.L3n4Addr.L4Addr.Protocol = "NONE"
+	}
+
 	hash := p.Frontend.Hash()
 	svc, found := s.svcByHash[hash]
+	if !found {
+		p.Frontend.L3n4Addr.L4Addr.Protocol = proto
+		for i, backend := range p.Backends {
+			backend.L3n4Addr.L4Addr.Protocol = backendProtos[i]
+		}
+
+		hash = p.Frontend.Hash()
+		svc, found = s.svcByHash[hash]
+	}
+
 	if !found {
 		// Allocate service ID for the new service
 		addrID, err := AcquireID(p.Frontend.L3n4Addr, uint32(p.Frontend.ID))

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service/healthserver"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // ErrLocalRedirectServiceExists represents an error when a Local redirect
@@ -1035,6 +1036,7 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 		be.State = updatedB.State
 		be.Preferred = updatedB.Preferred
 
+	nextService:
 		for id, info := range s.svcByID {
 			var p *datapathTypes.UpsertServiceParams
 			for i, b := range info.backends {
@@ -1049,10 +1051,17 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 				found := false
 
 				if p, found = updateSvcs[id]; !found {
+					proto, err := u8proto.ParseProtocol(info.frontend.L4Addr.Protocol)
+					if err != nil {
+						errs = errors.Join(errs, fmt.Errorf("failed to parse service protocol for frontend %+v: %w", info.frontend, err))
+						continue nextService
+					}
+
 					p = &datapathTypes.UpsertServiceParams{
 						ID:                        uint16(id),
 						IP:                        info.frontend.L3n4Addr.AddrCluster.AsNetIP(),
 						Port:                      info.frontend.L3n4Addr.L4Addr.Port,
+						Protocol:                  byte(proto),
 						PrevBackendsCount:         len(info.backends),
 						IPv6:                      info.frontend.IsIPv6(),
 						Type:                      info.svcType,
@@ -1563,11 +1572,16 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 		}
 	}
 	svc.svcNatPolicy = natPolicy
+	protocol, err := u8proto.ParseProtocol(svc.frontend.L3n4Addr.L4Addr.Protocol)
+	if err != nil {
+		return err
+	}
 
 	p := &datapathTypes.UpsertServiceParams{
 		ID:                        uint16(svc.frontend.ID),
 		IP:                        svc.frontend.L3n4Addr.AddrCluster.AsNetIP(),
 		Port:                      svc.frontend.L3n4Addr.L4Addr.Port,
+		Protocol:                  uint8(protocol),
 		PreferredBackends:         preferredBackends,
 		ActiveBackends:            activeBackends,
 		NonActiveBackends:         nonActiveBackends,

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -34,6 +34,7 @@ var protoNames = map[U8proto]string{
 var ProtoIDs = map[string]U8proto{
 	"all":    0,
 	"any":    0,
+	"none":   0,
 	"icmp":   1,
 	"tcp":    6,
 	"udp":    17,
@@ -55,4 +56,12 @@ func ParseProtocol(proto string) (U8proto, error) {
 		return u, nil
 	}
 	return 0, fmt.Errorf("unknown protocol '%s'", proto)
+}
+
+func FromNumber(proto uint8) (U8proto, error) {
+	_, ok := protoNames[U8proto(proto)]
+	if !ok {
+		return 0, fmt.Errorf("unknown protocol %d", proto)
+	}
+	return U8proto(proto), nil
 }


### PR DESCRIPTION
git cherry-pick f8367055fd7aca1b6b95ae9b804a0e4d6f11c535, 0cf22cc3c3ffa15e8255da5093b043225bcac032, b25daf90b166ac148e98729d6113daddedbaee75, 45a84b4d4af64919a8bec5ded54626091e4e5d4e

Run `ARCH=amd64 DOCKER_REGISTRY=docker.io DOCKER_DEV_ACCOUNT=<docker account> DOCKER_IMAGE_TAG=v1.16.6-conformance-fix make docker-cilium-image docker-operator-generic-image` to build the image.